### PR TITLE
Adds preflight check on db connections and user defaults to installer

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,8 @@ import os
 
 REGION = os.environ.get('REGION', "us-west-2")
 
-# database name
+# database properties
+USER = os.environ.get('SA_USER', "snowalert")
 DATABASE = os.environ.get('SA_DATABASE', "snowalert")
 WAREHOUSE = os.environ.get('SA_WAREHOUSE', "snowalert")
 

--- a/src/helpers/auth.py
+++ b/src/helpers/auth.py
@@ -7,7 +7,7 @@ import boto3
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
-import config
+from .. import config
 
 
 def load_pkb(p8_private_key: bytes, encrypted_password: Optional[bytes]) -> bytes:

--- a/src/helpers/db.py
+++ b/src/helpers/db.py
@@ -7,8 +7,8 @@ from typing import List
 
 import snowflake.connector
 
-from helpers import log
-
+from .. import config
+from . import log
 from .auth import load_pkb
 
 parser = argparse.ArgumentParser(description="Optionally takes in a password")
@@ -30,12 +30,17 @@ def retry(f, E=Exception, n=3):
 # Connecting
 ###
 
-def connect():
+def preflight_checks(ctx):
+    user_props = dict((x['property'], x['value']) for x in fetch(ctx, f'DESC USER {config.USER};'))
+    assert user_props.get('DEFAULT_ROLE') != 'null', f"default role on user {config.USER} must not be null"
+
+
+def connect(run_preflight_checks=True):
     p8_private_key = b64decode(os.environ['PRIVATE_KEY'])
     encrypted_pass = (args.private_key_password or os.environ['PRIVATE_KEY_PASSWORD']).encode('utf-8')
 
-    user = os.environ['SA_USER']
-    region = os.environ.get('REGION', 'us-west-2')
+    user = config.USER
+    region = config.REGION
     account = os.environ['SNOWFLAKE_ACCOUNT'] + ('' if region == 'us-west-2' else f'.{region}')
 
     try:
@@ -46,10 +51,23 @@ def connect():
             ocsp_response_cache_filename='/tmp/.cache/snowflake/ocsp_response_cache'
         ))
 
+        if run_preflight_checks:
+            preflight_checks(connection)
+
     except Exception as e:
         log.fatal(e, "Failed to connect.")
 
     return connection
+
+
+def fetch(ctx, query):
+    res = execute(ctx, query)
+    cols = [c[0] for c in res.description]
+    while True:
+        row = res.fetchone()
+        if row is None:
+            break
+        yield dict(zip(cols, row))
 
 
 def execute(ctx, query):

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -231,9 +231,11 @@ def setup_warehouse(do_attempt):
 
 
 def setup_user(do_attempt):
-    do_attempt("Creating user & role", [
+    defaults = f"login_name='{USER}' password='' default_role={ROLE} default_warehouse='{WAREHOUSE}'"
+    do_attempt("Creating role and user", [
         f"CREATE ROLE IF NOT EXISTS {ROLE}",
-        f"CREATE USER IF NOT EXISTS {USER} login_name='{USER}' password='' default_role={ROLE}",
+        f"CREATE USER IF NOT EXISTS {USER} {defaults}",
+        f"ALTER USER IF EXISTS {USER} SET {defaults}",  # in case user was manually created
     ])
     do_attempt("Granting role to user", f"GRANT ROLE {ROLE} TO USER {USER};")
     do_attempt("Granting privileges to role", GRANT_PRIVILEGES_QUERIES)


### PR DESCRIPTION
To test, ran with oz creds —

```c = db.connect()
db.preflight_checks(c)
```

in Python console and noted that no errors occurred. Also, ran the commands inside preflight_checks and made sure their results are as-expected, specifically:

```
In [77]: user_props = dict((x['property'], x['value']) for x in fetch(ctx, f'DESC USER {config.USER};'))

In [78]: user_props
Out[78]:
{'NAME': 'SNOWALERT',
 'COMMENT': 'null',
 'LOGIN_NAME': 'SNOWALERT',
 'DISPLAY_NAME': 'SNOWALERT',
 'FIRST_NAME': 'null',
 'MIDDLE_NAME': 'null',
 'LAST_NAME': 'null',
 'EMAIL': 'null',
 'PASSWORD': '********',
 'MUST_CHANGE_PASSWORD': 'false',
 'DISABLED': 'false',
 'SNOWFLAKE_LOCK': 'false',
 'SNOWFLAKE_SUPPORT': 'false',
 'DAYS_TO_EXPIRY': 'null',
 'MINS_TO_UNLOCK': 'null',
 'DEFAULT_WAREHOUSE': 'SNOWALERT',
 'DEFAULT_NAMESPACE': 'null',
 'DEFAULT_ROLE': 'SNOWALERT',
 'EXT_AUTHN_DUO': 'false',
 'EXT_AUTHN_UID': 'null',
 'MINS_TO_BYPASS_MFA': 'null',
 'MINS_TO_BYPASS_NETWORK_POLICY': 'null',
 'RSA_PUBLIC_KEY_FP': 'SHA256:Z+ZyWLbtJGWQm4egi++/Er7RkLaOaZTGBoQK9u/xsoM=',
 'RSA_PUBLIC_KEY_2_FP': 'null'}
```