### PR TITLE
Adds apply and revert buttons and a variety of minor cleanups

### DIFF
--- a/src/samui/frontend/src/actions/rules.ts
+++ b/src/samui/frontend/src/actions/rules.ts
@@ -59,8 +59,8 @@ export const SAVE_RULE_FAILURE = 'SAVE_RULE_FAILURE';
 
 export const SaveRuleAction = {
   saveRuleRequest: () => createAction(SAVE_RULE_REQUEST),
-  saveRuleSuccess: (response: LoadRulesPayload) => createAction(SAVE_RULE_SUCCESS, response),
-  saveRuleFailure: (errorMessage: string) => createAction(SAVE_RULE_FAILURE, errorMessage),
+  saveRuleSuccess: (response: SnowAlertRule) => createAction(SAVE_RULE_SUCCESS, response),
+  saveRuleFailure: (error: {message: string; rule: SnowAlertRule}) => createAction(SAVE_RULE_FAILURE, error),
 };
 
 export type SaveRuleActions = ActionsUnion<typeof SaveRuleAction>;
@@ -69,9 +69,13 @@ export const saveRule = (rule: SnowAlertRule) => async (dispatch: Dispatch) => {
   dispatch(createAction(SAVE_RULE_REQUEST, rule));
   try {
     const response = await api.saveRule(rule);
-    dispatch(SaveRuleAction.saveRuleSuccess(response.rules));
+    if (response.success) {
+      dispatch(SaveRuleAction.saveRuleSuccess(response.rule));
+    } else {
+      throw response;
+    }
   } catch (error) {
-    dispatch(SaveRuleAction.saveRuleFailure(error.message));
+    dispatch(SaveRuleAction.saveRuleFailure(error));
   }
 };
 

--- a/src/samui/frontend/src/components/RuleEditors/RawEditor.styl
+++ b/src/samui/frontend/src/components/RuleEditors/RawEditor.styl
@@ -1,0 +1,2 @@
+button
+	margin: 10px 10px 10px 0

--- a/src/samui/frontend/src/components/RuleEditors/RawEditor.tsx
+++ b/src/samui/frontend/src/components/RuleEditors/RawEditor.tsx
@@ -1,0 +1,79 @@
+import {Button, Icon, Input} from 'antd';
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators, Dispatch} from 'redux';
+
+import {getSnowAlertRules} from '../../reducers/rules';
+import {changeRuleBody, saveRule} from '../../actions/rules';
+
+import {State, SnowAlertRulesState} from '../../reducers/types';
+
+import './RawEditor.css';
+
+interface OwnProps {}
+
+interface DispatchProps {
+  changeRuleBody: typeof changeRuleBody;
+  saveRule: typeof saveRule;
+}
+
+interface StateProps {
+  rules: SnowAlertRulesState;
+}
+
+type RawEditorProps = OwnProps & DispatchProps & StateProps;
+
+class RawEditor extends React.PureComponent<RawEditorProps> {
+  render() {
+    const {currentRuleView, rules} = this.props.rules;
+    const rule = rules.find(r => `${r.title}_${r.target}_${r.type}` == currentRuleView);
+
+    return (
+      <div>
+        <Input.TextArea
+          disabled={!rule || rule.isSaving}
+          value={rule ? rule.body : ''}
+          spellCheck={false}
+          autosize={{minRows: 30, maxRows: 50}}
+          style={{fontFamily: 'Hack, monospace'}}
+          onChange={e => this.props.changeRuleBody(e.target.value)}
+        />
+        <Button
+          type="primary"
+          disabled={!rule || rule.isSaving || rule.savedBody == rule.body}
+          onClick={() => rule && this.props.saveRule(rule)}
+        >
+          {rule && rule.isSaving ? <Icon type="loading" theme="outlined" /> : <Icon type="upload" />} Apply
+        </Button>
+        <Button
+          type="default"
+          disabled={!rule || rule.isSaving || rule.savedBody == rule.body}
+          onClick={() => rule && this.props.changeRuleBody(rule.savedBody)}
+        >
+          <Icon type="rollback" theme="outlined" /> Revert
+        </Button>
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return bindActionCreators(
+    {
+      changeRuleBody,
+      saveRule,
+    },
+    dispatch,
+  );
+};
+
+const mapStateToProps = (state: State) => {
+  return {
+    rules: getSnowAlertRules(state),
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RawEditor);

--- a/src/samui/frontend/src/components/RuleEditors/index.ts
+++ b/src/samui/frontend/src/components/RuleEditors/index.ts
@@ -1,0 +1,3 @@
+import RawEditor from './RawEditor';
+
+export {RawEditor};

--- a/src/samui/frontend/src/components/RulesTree/RulesTree.tsx
+++ b/src/samui/frontend/src/components/RulesTree/RulesTree.tsx
@@ -1,4 +1,4 @@
-import {Tree} from 'antd';
+import {Icon, Tree} from 'antd';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch} from 'redux';
@@ -33,17 +33,17 @@ class RulesTree extends React.PureComponent<RulesTreeProps> {
     this.props.changeRule('');
   }
 
-  generateTree = (data: SnowAlertRulesState['rules'], target: SnowAlertRule['target']) => {
-    const queryTitles: Array<string> = [];
-    const suppressionTitles: Array<string> = [];
+  generateTree = (rules: SnowAlertRulesState['rules'], target: SnowAlertRule['target']) => {
+    const queries: Array<SnowAlertRule> = [];
+    const suppressions: Array<SnowAlertRule> = [];
 
-    for (let d of data)
-      if (d.target === target) {
-        if (d.type === 'query') {
-          queryTitles.push(d.title.substr(0, d.title.length - (target.length + '_QUERY'.length + 1)));
+    for (let rule of rules)
+      if (rule.target === target) {
+        if (rule.type === 'QUERY') {
+          queries.push(rule);
         }
-        if (d.type === 'suppression') {
-          suppressionTitles.push(d.title.substr(0, d.title.length - (target.length + '_SUPPRESSION'.length + 1)));
+        if (rule.type === 'SUPPRESSION') {
+          suppressions.push(rule);
         }
       }
 
@@ -52,14 +52,22 @@ class RulesTree extends React.PureComponent<RulesTreeProps> {
         {this.props.rules.isFetching ? (
           <TreeNode title="Loading..." />
         ) : (
-          queryTitles.map(x => <TreeNode key={`${x}_${target.toUpperCase()}_QUERY`} selectable title={x} />)
+          queries.map(r => (
+            <TreeNode selectable key={`${r.title}_${target}_QUERY`} title={(r.isSaving ? '(saving) ' : '') + r.title} />
+          ))
         )}
       </TreeNode>,
       <TreeNode key="suppressions" title="Suppressions" selectable={false}>
         {this.props.rules.isFetching ? (
           <TreeNode title="Loading..." />
         ) : (
-          suppressionTitles.map(x => <TreeNode key={`${x}_${target.toUpperCase()}_SUPPRESSION`} selectable title={x} />)
+          suppressions.map(r => (
+            <TreeNode
+              selectable
+              key={`${r.title}_${target}_SUPPRESSION`}
+              title={(r.isSaving ? '(saving) ' : '') + r.title}
+            />
+          ))
         )}
       </TreeNode>,
     ];
@@ -68,7 +76,7 @@ class RulesTree extends React.PureComponent<RulesTreeProps> {
   render() {
     var rules = this.props.rules.rules;
     return (
-      <Tree showLine defaultExpandAll onSelect={x => this.props.changeRule((x[0] || '').split('-')[0])}>
+      <Tree showLine defaultExpandAll onSelect={x => this.props.changeRule(x[0] || '')}>
         {this.generateTree(rules, this.props.target)}
       </Tree>
     );

--- a/src/samui/frontend/src/reducers/types.ts
+++ b/src/samui/frontend/src/reducers/types.ts
@@ -49,19 +49,19 @@ export interface ViewportState {
 }
 
 export interface SnowAlertRule {
-  readonly target: 'alert' | 'violation';
-  readonly type: 'query' | 'suppression';
+  readonly target: 'ALERT' | 'VIOLATION';
+  readonly type: 'QUERY' | 'SUPPRESSION';
   readonly title: string;
   readonly body: string;
   readonly savedBody: string;
+  readonly isSaving: boolean;
 }
 
 export interface SnowAlertRulesState {
   readonly errorMessage: null;
   readonly isFetching: boolean;
-  readonly isSaving: boolean;
   readonly rules: ReadonlyArray<SnowAlertRule>;
-  readonly currentRuleTitle: string | null;
+  readonly currentRuleView: string | null;
 }
 
 export interface State {

--- a/src/samui/frontend/src/routes/Dashboard/Alerts.tsx
+++ b/src/samui/frontend/src/routes/Dashboard/Alerts.tsx
@@ -57,7 +57,7 @@ class Alerts extends React.PureComponent<AlertsProps> {
           <Card title="Alerts Dashboard" className={'card'} bordered={true}>
             <div>
               <Row>
-                <OrganizationDetails data={{percent: 30}} target="alert" />
+                <OrganizationDetails data={{percent: 30}} target="ALERT" />
               </Row>
             </div>
           </Card>

--- a/src/samui/frontend/src/routes/Dashboard/Violations.tsx
+++ b/src/samui/frontend/src/routes/Dashboard/Violations.tsx
@@ -57,7 +57,7 @@ class Alerts extends React.PureComponent<AlertsProps> {
           <Card title="Violations Dashboard" className={'card'} bordered={true}>
             <div>
               <Row>
-                <OrganizationDetails data={{percent: 30}} target="violation" />
+                <OrganizationDetails data={{percent: 30}} target="VIOLATION" />
               </Row>
             </div>
           </Card>


### PR DESCRIPTION
- removed `.toUpperCase` from JS so constants on client are all-caps
- standardize on errors from server
- remove some of the string-encoding hacks requiring `.split('-')[0]`
- semantic consistency
  - views have names
  - rules have titles, targets, types
