### PR TITLE
adds has_no_violations udtf to create-udtfs.sql.fmt

### DIFF
--- a/src/scripts/installer-queries/create-udtfs.sql.fmt
+++ b/src/scripts/installer-queries/create-udtfs.sql.fmt
@@ -16,3 +16,13 @@ AS '
     , slice_end FROM TABLE(time_slices( num_slices, DATEADD(sec, -seconds_in_slice * num_slices, t), t ))
 '
 ;
+
+CREATE OR REPLACE FUNCTION snowalert.rules.has_no_violations(qid VARCHAR)
+RETURNS BOOLEAN
+AS '
+(
+  SELECT COUNT(*) AS c FROM snowalert.data.violations
+  WHERE created_time > DATEADD(day, -1, CURRENT_TIMESTAMP())
+    AND query_id = qid
+) = 0
+';


### PR DESCRIPTION
install.py already grants usage on all functions in the data schema to the role, so adding the function definition should be sufficient.