### PR TITLE
SA-k8sDeploy: Adding k8s manifests and docs

### DIFF
--- a/docs/src/pages/k8s.rst
+++ b/docs/src/pages/k8s.rst
@@ -1,0 +1,35 @@
+Kubernetes (k8s)
+****************
+
+Overview
+========
+
+Deploying SnowAlert in k8s is relatively straightforwared.
+It consists of a k8s Deployment type that is for the SnowAlert UI,
+and an associated service with the type LoadBalancer. Additionally
+there is a CronJob type that runs the SnowAlert runner. The
+secrets are all managed via k8s.
+
+Overview
+========
+Using the included manifests is a good start to get up and running,
+however you will want to adjust namespaces and create roles that are
+suitable for your environment.
+
+Quickstart
+==========
+To use the included manifests (warninig, they will deploy into the default
+namespace). Modify the sa-secrets.yaml file with base64 encoded values that are
+the result of the non-KMS install process (i.e. the values contained within the
+envs file).
+
+To Deploy
+=========
+Assuming you have kubectl configured and pointing to your cluster you can execute
+
+.. code::
+
+    $ kubectl apply -f manifests 
+
+from within the /infra/k8s/ directory.
+

--- a/infra/k8s/manifests/sa-runner-cronjob.yaml
+++ b/infra/k8s/manifests/sa-runner-cronjob.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: snowalert
+  labels:
+    app: snowalert-ui
+  annotations:
+    monitoring: "true"
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - image: snowsec/snowalert:1.7.2-rc
+            name: snowalert
+            resources:
+              limits:
+                memory: "2Gi"
+                cpu: "1000m"
+              requests: 
+                memory: "1Gi"
+                cpu: "500m"
+            env:
+              - name: SA_ROLE
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: SA_ROLE
+              - name: SA_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: SA_DATABASE
+              - name: SA_WAREHOUSE
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: SA_WAREHOUSE
+              - name: REGION
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: REGION
+              - name: SNOWFLAKE_ACCOUNT
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: SNOWFLAKE_ACCOUNT
+              - name: PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: PRIVATE_KEY
+              - name: PRIVATE_KEY_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: PRIVATE_KEY_PASSWORD
+              - name: JIRA_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: JIRA_URL
+              - name: JIRA_PROJECT
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: JIRA_PROJECT
+              - name: JIRA_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: JIRA_USER
+              - name: JIRA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: snowalert-secrets
+                    key: JIRA_PASSWORD
+          restartPolicy: Never

--- a/infra/k8s/manifests/sa-secrets.yaml
+++ b/infra/k8s/manifests/sa-secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: snowalert-secrets
+  namespace: default
+type: Opaque
+data:
+  OAUTH_CLIENT_<accountName>: <base64 Encoded Client ID>
+  OAUTH_SECRET_<accountName>: <base64 Encoded Client Secret>
+  SA_ROLE: <base64 Encoded SA_ROLE>
+  SA_DATABASE: <base64 Encoded SA_DATABASE>
+  SA_WAREHOUSE: <base64 Encoded SA_WAREHOUSE>
+  REGION: <base64 Encoded REGION>
+  SNOWFLAKE_ACCOUNT: <base64 Encoded SNOWFLAKE_ACCOUNT>
+  PRIVATE_KEY: <base64 Encoded PRIVATE_KEY>
+  PRIVATE_KEY_PASSWORD: <base64 Encoded PRIVATE_KEY_PASSWORD>
+  JIRA_URL: <base64 Encoded JIRA_URL>
+  JIRA_PROJECT: <base64 Encoded JIRA_URL>
+  JIRA_USER: <base64 Encoded JIRA_USER>
+  JIRA_PASSWORD: <base64 Encoded JIRA_PASSWORD>

--- a/infra/k8s/manifests/sa-ui-deployment.yaml
+++ b/infra/k8s/manifests/sa-ui-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snowalert-ui
+  labels:
+    app: snowalert
+  annotations:
+    monitoring: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snowalert-ui
+  template:
+    metadata:
+      labels:
+        app: snowalert-ui
+    spec:
+      containers:
+      - image: snowsec/snowalert-webui:1.7.2-rc
+        name: snowalert-ui
+        resources:
+          limits:
+            memory: "2Gi"
+            cpu: "1000m"
+          requests: 
+            memory: "1Gi"
+            cpu: "500m"
+        ports:
+          - containerPort: 8000
+        env:
+          - name: OAUTH_CLIENT_VA_DEMO07
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: OAUTH_CLIENT_VA_DEMO07
+          - name: OAUTH_SECRET_VA_DEMO07
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: OAUTH_SECRET_VA_DEMO07
+          - name: SA_ROLE
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: SA_ROLE
+          - name: SA_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: SA_DATABASE
+          - name: SA_WAREHOUSE
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: SA_WAREHOUSE
+          - name: REGION
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: REGION
+          - name: SNOWFLAKE_ACCOUNT
+            valueFrom:
+              secretKeyRef:
+                name: snowalert-secrets
+                key: SNOWFLAKE_ACCOUNT

--- a/infra/k8s/manifests/sa-ui-deployment.yaml
+++ b/infra/k8s/manifests/sa-ui-deployment.yaml
@@ -29,16 +29,16 @@ spec:
         ports:
           - containerPort: 8000
         env:
-          - name: OAUTH_CLIENT_VA_DEMO07
+          - name: OAUTH_CLIENT_<account_name>
             valueFrom:
               secretKeyRef:
                 name: snowalert-secrets
-                key: OAUTH_CLIENT_VA_DEMO07
-          - name: OAUTH_SECRET_VA_DEMO07
+                key: OAUTH_CLIENT_<account_name>
+          - name: OAUTH_SECRET_<account_name>
             valueFrom:
               secretKeyRef:
                 name: snowalert-secrets
-                key: OAUTH_SECRET_VA_DEMO07
+                key: OAUTH_SECRET_<account_name>
           - name: SA_ROLE
             valueFrom:
               secretKeyRef:

--- a/infra/k8s/manifests/sa-ui-service.yaml
+++ b/infra/k8s/manifests/sa-ui-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snowalert-service
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000
+  selector: {
+    app: snowalert-ui
+  }
+  type: LoadBalancer


### PR DESCRIPTION
This PR adds k8s manifests for secrets, the runner, and the web ui, with an associated service.

I wrote RST documentation, but did not link it up to the index to avoid any possible merge conflicts. 
Let me know if you need any other information!

Also let me know if you are ok with the structure of `infra`