### PR TITLE
Seperating Ingest and Connector logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ src/**/lib/
 
 *.pyc
 *.venv
+venv
 *.db
 *.egg-info

--- a/src/runners/connectors_runner.py
+++ b/src/runners/connectors_runner.py
@@ -1,0 +1,68 @@
+"""SA Connections Runner (SAIR)
+
+ SAIR processes Data Connections in *_CONNECTION tables
+
+"""
+
+import importlib
+from datetime import datetime
+from types import GeneratorType
+from runners.helpers import log
+from runners.helpers import db
+from runners.helpers import kms
+from runners.config import RUN_ID
+from runners.config import DC_METADATA_TABLE
+
+import yaml
+
+
+def main(connection_table="%_CONNECTION"):
+    log.info('--- Data Connections Ingest ---')
+    # data connections
+    for table in db.fetch(f"SHOW TABLES LIKE '{connection_table}' IN data"):
+        table_name = table['name']
+        table_comment = table['comment']
+
+        log.info(f"-- START DC {table_name} --")
+        try:
+            options = yaml.load(table_comment) or {}
+
+            if 'module' in options:
+                module = options['module']
+
+                metadata = {
+                    'RUN_ID': RUN_ID,
+                    'TYPE': module,
+                    'START_TIME': datetime.utcnow(),
+                    'LANDING_TABLE': table_name,
+                    'INGEST_COUNT': 0
+                }
+
+                connector = importlib.import_module(f"connectors.{module}")
+
+                for module_option in connector.CONNECTION_OPTIONS:
+                    name = module_option['name']
+                    if module_option.get('secret') and name in options:
+                        options[name] = kms.decrypt_if_encrypted(options[name])
+
+                if callable(getattr(connector, 'ingest', None)):
+                    ingested = connector.ingest(table_name, options)
+                    if isinstance(ingested, int):
+                        metadata['INGEST_COUNT'] += ingested
+                    elif isinstance(ingested, GeneratorType):
+                        for n in ingested:
+                            metadata['INGEST_COUNT'] += n
+                    else:
+                        metadata['INGESTED'] = ingested
+
+                db.record_metadata(metadata, table=DC_METADATA_TABLE)
+
+        except Exception as e:
+            log.error(f"Error loading logs into {table_name}: ", e)
+            db.record_metadata(metadata, table=DC_METADATA_TABLE, e=e)
+
+        log.info(f"-- END DC --")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/runners/ingest_runner.py
+++ b/src/runners/ingest_runner.py
@@ -1,21 +1,16 @@
 """SA Ingestion Runner (SAIR)
 
 1. SAIR processes all the files in the src/ingestion folder
-2. SAIR processes Data Connections in *_CONNECTION tables
 
 """
-from datetime import datetime
-import importlib
 import os
 import subprocess
-from types import GeneratorType
-import yaml
 
-from runners.config import DC_METADATA_TABLE, RUN_ID
-from runners.helpers import log, db, kms
+from runners.helpers import log
 
 
-def main(connection_table="%_CONNECTION"):
+def main():
+    log.info('--- Processing Ingest ---')
     # ingestion scripts
     for name in os.listdir('../ingestion'):
         log.info(f"invoking {name}")
@@ -25,53 +20,6 @@ def main(connection_table="%_CONNECTION"):
             log.info(f"{name} invoked")
         except Exception as e:
             log.error(f"failed to run {name}", e)
-
-    log.info('--- Data Connections Ingest ---')
-
-    # data connections
-    for table in db.fetch(f"SHOW TABLES LIKE '{connection_table}' IN data"):
-        table_name = table['name']
-        table_comment = table['comment']
-
-        log.info(f"-- START DC {table_name} --")
-        try:
-            options = yaml.load(table_comment) or {}
-
-            if 'module' in options:
-                module = options['module']
-
-                metadata = {
-                    'RUN_ID': RUN_ID,
-                    'TYPE': module,
-                    'START_TIME': datetime.utcnow(),
-                    'LANDING_TABLE': table_name,
-                    'INGEST_COUNT': 0
-                }
-
-                connector = importlib.import_module(f"connectors.{module}")
-
-                for module_option in connector.CONNECTION_OPTIONS:
-                    name = module_option['name']
-                    if module_option.get('secret') and name in options:
-                        options[name] = kms.decrypt_if_encrypted(options[name])
-
-                if callable(getattr(connector, 'ingest', None)):
-                    ingested = connector.ingest(table_name, options)
-                    if isinstance(ingested, int):
-                        metadata['INGEST_COUNT'] += ingested
-                    elif isinstance(ingested, GeneratorType):
-                        for n in ingested:
-                            metadata['INGEST_COUNT'] += n
-                    else:
-                        metadata['INGESTED'] = ingested
-
-                db.record_metadata(metadata, table=DC_METADATA_TABLE)
-
-        except Exception as e:
-            log.error(f"Error loading logs into {table_name}: ", e)
-            db.record_metadata(metadata, table=DC_METADATA_TABLE, e=e)
-
-        log.info(f"-- END DC --")
 
 
 if __name__ == "__main__":

--- a/src/runners/run.py
+++ b/src/runners/run.py
@@ -2,7 +2,7 @@
 
 import fire
 
-from runners import ingest_runner
+from runners import ingest_runner, connectors_runner
 from runners import baseline_runner
 
 from runners import alert_queries_runner
@@ -52,6 +52,10 @@ def main(target="all", rule_name=None):
 
         if target in ['ingest']:
             ingest_runner.main()
+            connectors_runner.main()
+
+        if target in ['connectors']:
+            connectors_runner.main()
 
         if target in ['baseline', 'baselines']:
             baseline_runner.main()


### PR DESCRIPTION
This PR separates the ingest into 2 separate runners for clarity, and then adds the `connectors` parameter to only process the data connector ingest. 

To preserve current behavior `ingest` will process the data as before (i.e. going through the `/ingestion` dir and then processing connectors). This can be removed in the future, if desired.

Additionally it adds venv to the gitignore as I know that pycharm loves to call the built in virtualenv `venv` vs `.venv`