### PR TITLE
Modified Login Portal for Internal Use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ src/**/lib/
 *.venv
 *.db
 *.egg-info
+*.envs
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.7-slim-stretch
+
+WORKDIR /var/task
+
+RUN pip install --upgrade pip virtualenv pyflakes
+
+RUN mkdir -p ./snowalert
+RUN virtualenv ./snowalert/venv
+ENV PATH="/var/task/snowalert/venv/bin:${PATH}"
+
+COPY ./src ./snowalert/src
+
+# backend
+RUN apt-get update \
+ && apt-get install -y gcc linux-libc-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && PYTHONPATH='' pip install ./snowalert/src/ ./snowalert/src/webui/backend/ \
+ && apt-get purge -y --auto-remove gcc linux-libc-dev
+
+# frontend
+RUN apt-get update \
+ && apt-get install -y curl gnupg2 apt-transport-https \
+ && curl -sL https://deb.nodesource.com/setup_11.x | bash - \
+ && apt-get install -y nodejs \
+ && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+ && apt-get update \
+ && apt-get install -y yarn \
+ && cd ./snowalert/src/webui/frontend && yarn install && yarn build \
+ && rm -fr node_modules \
+ && apt-get purge -y --auto-remove curl gnupg2 apt-transport-https nodejs yarn
+
+# link frontend build into backend venv
+RUN ln -s $PWD/snowalert/src/webui/frontend ./snowalert/venv/lib/python3.7/
+
+CMD python ./snowalert/src/webui/backend/webui/app.py

--- a/src/runners/helpers/db.py
+++ b/src/runners/helpers/db.py
@@ -12,7 +12,7 @@ from snowflake.connector.network import MASTER_TOKEN_EXPIRED_GS_CODE, OAUTH_AUTH
 
 from . import log
 from .auth import load_pkb, oauth_refresh
-from .dbconfig import ACCOUNT, ROLE, DATABASE, USER, WAREHOUSE, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, TIMEOUT
+from .dbconfig import HOST, PORT, PROTOCOL, ACCOUNT, ROLE, DATABASE, USER, WAREHOUSE, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, TIMEOUT
 from .dbconnect import snowflake_connect
 
 from runners import utils
@@ -58,6 +58,9 @@ def connect(flush_cache=False, oauth={}):
 
     def connect():
         return connect_db(
+            host=HOST,
+            port=PORT,
+            protocol=PROTOCOL,
             account=oauth_account or ACCOUNT,
             database=DATABASE,
             user=oauth_username or USER,

--- a/src/runners/helpers/dbconfig.py
+++ b/src/runners/helpers/dbconfig.py
@@ -15,18 +15,26 @@ if ENV == 'test':
 else:
     tail = ''
 
-# database & account properties
-REGION = environ.get('REGION', "us-west-2")
-REGION_SUBDOMAIN_POSTFIX = '' if REGION == 'us-west-2' else f'.{REGION}'
-ACCOUNT = environ.get('SNOWFLAKE_ACCOUNT', '') + REGION_SUBDOMAIN_POSTFIX
 
-USER = environ.get('SA_USER', "snowalert") + tail
+
+# database & account properties
+# For customer: HOST = '', PORT = '443', PROTOCOL = 'https'
+# For internal use: REGION = ''
+HOST = environ.get('SNOWFLAKE_HOST', '') # '' for customer,
+PORT = environ.get('SH_PORT')
+PROTOCOL = environ.get('SH_PROTOCOL')
+
+REGION = environ.get('SH_REGION', "us-west-2")
+REGION_SUBDOMAIN_POSTFIX = '' if REGION == 'us-west-2' else f'.{REGION}'
+ACCOUNT = environ.get('SH_ACCOUNT', '') if HOST else environ.get('SH_ACCOUNT', '') + REGION_SUBDOMAIN_POSTFIX
+
+USER = environ.get('SH_USER', "snowalert") + tail
 PRIVATE_KEY_PASSWORD = environ.get('PRIVATE_KEY_PASSWORD', '').encode('utf-8')
 PRIVATE_KEY = b64decode(environ['PRIVATE_KEY']) if environ.get('PRIVATE_KEY') else None
 
-ROLE = environ.get('SA_ROLE', "snowalert") + tail
-WAREHOUSE = environ.get('SA_WAREHOUSE', "snowalert") + tail
-DATABASE = environ.get('SA_DATABASE', "snowalert") + tail
+ROLE = environ.get('SH_ROLE', "snowalert") + tail
+WAREHOUSE = environ.get('SH_WAREHOUSE', "snowalert") + tail
+DATABASE = environ.get('SH_DATABASE', "snowalert") + tail
 
 # connection properties
 TIMEOUT = environ.get('SA_TIMEOUT', 500)


### PR DESCRIPTION
Hi, I have modified the Login Portal. The install interface looks exactly the same and the customer would not even notice it. But for internal use, they should input "snowhouse.preprod2.int.snowflakecomputing.com:8084" 
for the first question. 

The .envs file shall look like this now: 

SNOWFLAKE_HOST
SH_ACCOUNT
SH_USER
SH_ROLE
SH_DATABASE
SH_WAREHOUSE
SH_REGION
SH_PORT
SH_PROTOCOL
PRIVATE_KEY
PRIVATE_KEY_PASSWORD

