### PR TITLE
collects aws account information to snowflake

### DIFF
--- a/src/ingestion/ec2_describe_instances.py
+++ b/src/ingestion/ec2_describe_instances.py
@@ -7,7 +7,7 @@ import os
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from multiprocessing import Pool
-from runners.utils import groups_of, json_dumps
+from runners.utils import groups_of
 from runners.helpers import db
 
 import snowflake.connector

--- a/src/ingestion/ec2_describe_instances.py
+++ b/src/ingestion/ec2_describe_instances.py
@@ -7,12 +7,14 @@ import os
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from multiprocessing import Pool
-from runners.utils import groups_of
+from runners.utils import groups_of, json_dumps
+from runners.helpers import db
 
 import snowflake.connector
 
 INSTANCES_TABLE = os.environ['EC2_INSTANCE_LIST_SNOWFLAKE_TABLE_IDENTIFIER']
 AWS_ACCOUNTS_TABLE = os.environ['LIST_ACCOUNTS_SNOWFLAKE_TABLE_IDENTIFIER']
+AWS_ACCOUNTS_INFORMATION_TABLE = os.environ['AWS_ACCOUNTS_INFORMATION_TABLE_IDENTIFIER']
 AWS_AUDIT_ROLE_NAME = os.environ['AWS_AUDIT_DESTINATION_ROLE_NAME']
 SA_ACCOUNT = os.environ['INGEST_SNOWFLAKE_ACCOUNT']
 SA_USER = os.environ['INGEST_SNOWFLAKE_USER']
@@ -114,12 +116,18 @@ def get_data_worker(account):
                 instances.extend(region)
             except Exception as e:
                 print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
+                db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], None, json_dumps(e))])
                 return None
         instance_list = [json.dumps({**instance,"AccountId":account[0]}, default=str) for instance in instances]
+        try:
+            db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], len(instance_list), None)])
+        except Exception:
+            print('Failed to insert into AWS_ACCOUNT_INFORMATION table.')
         print(f"ec2_describe_instances: account: {account[1]} instances: {len(instance_list)}")
         return instance_list
     except Exception as e:
         print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
+        db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], None, json_dumps(e))])
         return None
 
 def get_data(accounts_list):

--- a/src/ingestion/ec2_describe_instances.py
+++ b/src/ingestion/ec2_describe_instances.py
@@ -116,30 +116,42 @@ def get_data_worker(account):
                 instances.extend(region)
             except Exception as e:
                 print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
-                db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
-                                                                   account[0],
-                                                                   account[1],
-                                                                   None,
-                                                                   e)])
+                db.insert(
+                    AWS_ACCOUNTS_INFORMATION_TABLE, values=[(
+                        datetime.datetime.utcnow(),
+                        account[0],
+                        account[1],
+                        None,
+                        e
+                    )]
+                )
                 return None
         instance_list = [json.dumps({**instance,"AccountId":account[0]}, default=str) for instance in instances]
         try:
-            db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
-                                                               account[0],
-                                                               account[1],
-                                                               len(instance_list),
-                                                               None)])
+            db.insert(
+                AWS_ACCOUNTS_INFORMATION_TABLE, values=[(
+                    datetime.datetime.utcnow(),
+                    account[0],
+                    account[1],
+                    len(instance_list),
+                    None
+                )]
+            )
         except Exception:
             print('Failed to insert into AWS_ACCOUNT_INFORMATION table.')
         print(f"ec2_describe_instances: account: {account[1]} instances: {len(instance_list)}")
         return instance_list
     except Exception as e:
         print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
-        db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
-                                                           account[0],
-                                                           account[1],
-                                                           None,
-                                                           e)])
+        db.insert(
+            AWS_ACCOUNTS_INFORMATION_TABLE, values=[(
+                datetime.datetime.utcnow(),
+                account[0],
+                account[1],
+                None,
+                e
+            )]
+        )
         return None
 
 def get_data(accounts_list):

--- a/src/ingestion/ec2_describe_instances.py
+++ b/src/ingestion/ec2_describe_instances.py
@@ -116,18 +116,30 @@ def get_data_worker(account):
                 instances.extend(region)
             except Exception as e:
                 print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
-                db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], None, json_dumps(e))])
+                db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
+                                                                   account[0],
+                                                                   account[1],
+                                                                   None,
+                                                                   e)])
                 return None
         instance_list = [json.dumps({**instance,"AccountId":account[0]}, default=str) for instance in instances]
         try:
-            db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], len(instance_list), None)])
+            db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
+                                                               account[0],
+                                                               account[1],
+                                                               len(instance_list),
+                                                               None)])
         except Exception:
             print('Failed to insert into AWS_ACCOUNT_INFORMATION table.')
         print(f"ec2_describe_instances: account: {account[1]} instances: {len(instance_list)}")
         return instance_list
     except Exception as e:
         print(f"ec2_describe_instances: account: {account[1]} exception: {e}")
-        db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(), account[0], account[1], None, json_dumps(e))])
+        db.insert(AWS_ACCOUNTS_INFORMATION_TABLE, values=[(datetime.datetime.utcnow(),
+                                                           account[0],
+                                                           account[1],
+                                                           None,
+                                                           e)])
         return None
 
 def get_data(accounts_list):

--- a/src/runners/helpers/db.py
+++ b/src/runners/helpers/db.py
@@ -227,7 +227,7 @@ def insert(table, values, overwrite=False, select=""):
         f";"
     )
 
-    jsony = (dict, list, tuple)
+    jsony = (dict, list, tuple, Exception)
     params_with_json = [
         [utils.json_dumps(v) if isinstance(v, jsony) else v for v in vp]
         for vp in values


### PR DESCRIPTION
This is not a perfect solution, but it ingests a collection of data (account id, account alias, number of instances, or an error) to snowflake (and since it's in a try/catch block, if the insert fails for any reason it doesn't kill the rest of the ingest process).

I'd do more refactoring of the script itself (e.g. to use the db functions instead of constructing raw sql) but this script will be obsoleted with a connector soon and it doesn't seem like a productive use of time to fix this up more than this.