### PR TITLE
Jira project

### DIFF
--- a/src/runners/handlers/jira.py
+++ b/src/runners/handlers/jira.py
@@ -144,8 +144,9 @@ def bail_out(alert_id):
         log.error(e, f"Failed to update alert {alert_id} with handler status")
 
 
-def handle(alert, correlation_id):
-    globals()['PROJECT'] = alert['HANDLER'].get('PROJECT', environ.get('JIRA_PROJECT', ''))
+def handle(alert, correlation_id, project=PROJECT):
+    global PROJECT
+    PROJECT = project
     if PROJECT == '':
         log.error("No Jira project defined")
         return "No Jira Project defined"

--- a/src/runners/handlers/jira.py
+++ b/src/runners/handlers/jira.py
@@ -145,6 +145,7 @@ def bail_out(alert_id):
 
 
 def handle(alert, correlation_id):
+    globals()['PROJECT'] = alert['HANDLER'].get('PROJECT', environ.get('JIRA_PROJECT', ''))
     if PROJECT == '':
         log.error("No Jira project defined")
         return "No Jira Project defined"


### PR DESCRIPTION
Tested in dev account by creating an alert with the following handler defined:

```
     , ARRAY_CONSTRUCT(
       OBJECT_CONSTRUCT(
         'type', 'jira',
         'project', 'FOO'
        )
        ) AS handlers
```

And verified that the ticket was sent to the FOO project as opposed to the project defined in the environment variables. Additionally, tested a ticket with no defined handler and verified that it was sent to the environment-defined project as normal.