### PR TITLE
Records timestamp of snapshot creation as event_time

### DIFF
--- a/migrations/v1_8_1-v1_8_2.md
+++ b/migrations/v1_8_1-v1_8_2.md
@@ -4,27 +4,7 @@
 
 ### Event Time from Snapshot filenames
 
-In the v1.8.2 AWS Config DC, we now collect the `event_time` from the file name of the Config snapshots in S3 and have renamed AWS's `configurationItemCaptureTime` to be collected more clearly as `configuration_item_capture_time`.
-
-To keep Azure Config Connections working, please run a migration like the following on your landing table —
-
-~~~
-ALTER TABLE data.config_default_events_connection
-  RENAME COLUMN event_time
-             TO configuration_item_capture_time
-;
-ALTER TABLE data.config_default_events_connection
-  ADD COLUMN event_time TIMESTAMP_LTZ(9)
-;
-~~~
-
-or, if you're OK with restarting ingestion, just drop it —
-
-~~~
-DROP TABLE data.config_default_events_connection;
-~~~
-
-And recreate the connection via the Data Connector WebUI.
+In the v1.8.2 AWS Config DC, we now collect the `event_time` from the file name of the Config snapshots in S3 and have renamed AWS's `configurationItemCaptureTime` to be collected more clearly as `configuration_item_capture_time`. Due to the significance of the changes, the only way to migrate is to re-create the collection architecture.
 
 If you'd like to delete the Data Connector entirely you can do so a snippet like —
 
@@ -35,13 +15,7 @@ DROP STAGE data.config_default_events_stage;
 DROP TABLE data.config_default_events_staging;
 DROP STREAM data.config_default_events_stream;
 DROP TASK data.config_default_events_task;
+DROP TABLE data.config_default_events_connection;
 ~~~
 
-### Corrected Base Name
-
-The landing table is now named similarly to others to start with the `aws_config` prefix, matching the Python module. This change does not yet affect anything, but can be migrated by deleting and re-creating the ingestion pipeline as above and renaming the landing table with.
-
-~~~
-ALTER TABLE data.config_default_events_pipe
-  RENAME TO data.aws_config_default_events_pipe;
-~~~
+And recreate the connection via the Data Connector WebUI. Note that we've also updated the landing table and prefix to include "`aws_`" at the start, so that all your AWS landing tables line up alphabetically!

--- a/migrations/v1_8_1-v1_8_2.md
+++ b/migrations/v1_8_1-v1_8_2.md
@@ -1,0 +1,47 @@
+## AWS Config Data Connector
+
+> Note: we say "like" below because if you set a custom name on your AWS Config Data Connector, you'll need to replace `default` in the above snippets with that custom name.
+
+### Event Time from Snapshot filenames
+
+In the v1.8.2 AWS Config DC, we now collect the `event_time` from the file name of the Config snapshots in S3 and have renamed AWS's `configurationItemCaptureTime` to be collected more clearly as `configuration_item_capture_time`.
+
+To keep Azure Config Connections working, please run a migration like the following on your landing table —
+
+~~~
+ALTER TABLE data.config_default_events_connection
+  RENAME COLUMN event_time
+             TO configuration_item_capture_time
+;
+ALTER TABLE data.config_default_events_connection
+  ADD COLUMN event_time TIMESTAMP_LTZ(9)
+;
+~~~
+
+or, if you're OK with restarting ingestion, just drop it —
+
+~~~
+DROP TABLE data.config_default_events_connection;
+~~~
+
+And recreate the connection via the Data Connector WebUI.
+
+If you'd like to delete the Data Connector entirely you can do so a snippet like —
+
+~~~
+USE ROLE snowalert;
+DROP PIPE data.config_default_events_pipe;
+DROP STAGE data.config_default_events_stage;
+DROP TABLE data.config_default_events_staging;
+DROP STREAM data.config_default_events_stream;
+DROP TASK data.config_default_events_task;
+~~~
+
+### Corrected Base Name
+
+The landing table is now named similarly to others to start with the `aws_config` prefix, matching the Python module. This change does not yet affect anything, but can be migrated by deleting and re-creating the ingestion pipeline as above and renaming the landing table with.
+
+~~~
+ALTER TABLE data.config_default_events_pipe
+  RENAME TO data.aws_config_default_events_pipe;
+~~~

--- a/src/connectors/aws_config.py
+++ b/src/connectors/aws_config.py
@@ -55,7 +55,7 @@ LANDING_TABLE_COLUMNS = [
     ('aws_region', 'STRING'),
     ('arn', 'STRING'),
     ('availability_zone', 'STRING'),
-    ('resource_creation_time', 'TIMESTAMP_LTZ(9)'),
+    ('resource_modification_time', 'TIMESTAMP_LTZ(9)'),
     ('resource_name', 'STRING'),
     ('resource_Id', 'STRING'),
     ('resource_type', 'STRING'),
@@ -177,7 +177,7 @@ def finalize(connection_name):
     config_ingest_task = f'''
 INSERT INTO {landing_table} (
   raw, hash_raw, event_time, configuration_item_capture_time, account_id, aws_region, resource_type, arn,
-  availability_zone, resource_creation_time, resource_name, resource_Id, relationships, configuration, tags
+  availability_zone, resource_modification_time, resource_name, resource_Id, relationships, configuration, tags
 )
 SELECT value raw
     , HASH(value) hash_raw
@@ -188,7 +188,7 @@ SELECT value raw
     , value:resourceType::STRING aws_region
     , value:ARN::STRING arn
     , value:availabilityZone::STRING availability_zone
-    , value:resourceCreationTime::TIMESTAMP_LTZ(9) resource_creation_time
+    , value:resourceCreationTime::TIMESTAMP_LTZ(9) resource_modification_time
     , value:resourceName::STRING resource_name
     , value:resourceId::STRING resource_Id
     , value:relationships::VARIANT relationships

--- a/src/connectors/aws_config.py
+++ b/src/connectors/aws_config.py
@@ -50,6 +50,7 @@ LANDING_TABLE_COLUMNS = [
     ('raw', 'VARIANT'),
     ('hash_raw', 'NUMBER'),
     ('event_time', 'TIMESTAMP_LTZ(9)'),
+    ('configuration_item_capture_time', 'TIMESTAMP_LTZ(9)'),
     ('account_id', 'STRING'),
     ('aws_region', 'STRING'),
     ('arn', 'STRING'),
@@ -175,12 +176,13 @@ def finalize(connection_name):
 
     config_ingest_task = f'''
 INSERT INTO {landing_table} (
-  raw, hash_raw, event_time, account_id, aws_region, resource_type, arn, availability_zone,
-  resource_creation_time, resource_name, resource_Id, relationships, configuration, tags
+  raw, hash_raw, event_time, configuration_item_capture_time, account_id, aws_region, resource_type, arn,
+  availability_zone, resource_creation_time, resource_name, resource_Id, relationships, configuration, tags
 )
 SELECT value raw
     , HASH(value) hash_raw
-    , value:configurationItemCaptureTime::TIMESTAMP_LTZ(9) event_time
+    , current_timestamp() event_time
+    , value:configurationItemCaptureTime::TIMESTAMP_LTZ(9) configuration_item_capture_time
     , value:awsAccountId::STRING account_id
     , value:awsRegion::STRING aws_region
     , value:resourceType::STRING aws_region

--- a/src/connectors/aws_config.py
+++ b/src/connectors/aws_config.py
@@ -49,7 +49,7 @@ FILE_FORMAT = """
 LANDING_TABLE_COLUMNS = [
     ('raw', 'VARIANT'),
     ('hash_raw', 'NUMBER'),
-    ('event_time', 'TIMESTAMP_LTZ(9)'),
+    ('insertion_time', 'TIMESTAMP_LTZ(9)'),
     ('configuration_item_capture_time', 'TIMESTAMP_LTZ(9)'),
     ('account_id', 'STRING'),
     ('aws_region', 'STRING'),
@@ -176,12 +176,12 @@ def finalize(connection_name):
 
     config_ingest_task = f'''
 INSERT INTO {landing_table} (
-  raw, hash_raw, event_time, configuration_item_capture_time, account_id, aws_region, resource_type, arn,
+  raw, hash_raw, insertion_time, configuration_item_capture_time, account_id, aws_region, resource_type, arn,
   availability_zone, resource_creation_time, resource_name, resource_Id, relationships, configuration, tags
 )
 SELECT value raw
     , HASH(value) hash_raw
-    , current_timestamp() event_time
+    , current_timestamp() insertion_time
     , value:configurationItemCaptureTime::TIMESTAMP_LTZ(9) configuration_item_capture_time
     , value:awsAccountId::STRING account_id
     , value:awsRegion::STRING aws_region


### PR DESCRIPTION
tested in dev by running the UI locally and creating the connector, hooking it up to an S3 bucket in a sandbox account, and manually uploading config snapshots to the s3 bucket