### PR TITLE
Rename the Cloudtrail comment to aws_cloudtrail

### DIFF
--- a/src/connectors/aws_cloudtrail.py
+++ b/src/connectors/aws_cloudtrail.py
@@ -116,7 +116,7 @@ def connect(connection_name, options):
 
     comment = f'''
 ---
-module: cloudtrail
+module: aws_cloudtrail
 '''
 
     db.create_stage(


### PR DESCRIPTION
ModuleNotFoundError: No module named 'connectors.cloudtrail'