### PR TITLE
Upgrade snowflake-connector-python to 1.9.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -31,7 +31,7 @@ requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0
 s3transfer==0.1.13
 six==1.11.0
-snowflake-connector-python==1.7.0
+snowflake-connector-python==1.9.0
 snowflake-sqlalchemy==1.1.2
 SQLAlchemy==1.3.3
 urllib3==1.24.2

--- a/src/setup.py
+++ b/src/setup.py
@@ -9,7 +9,7 @@ setup(
         'fire==0.1.3',
         'jira==2.0.0',
         'PyYAML==4.2b1',
-        'snowflake-connector-python==1.8.4',
+        'snowflake-connector-python==1.9.0',
         'snowflake-sqlalchemy==1.1.2',
         'pandas==0.24.1',
         'pybrake==0.4.0',


### PR DESCRIPTION
Snowflake support suggested I upgrade client version to latest. This seems to help with the JWT invalid token issue somewhat.