### PR TITLE
Add fire library to connectors_runner.py

### DIFF
--- a/src/runners/connectors_runner.py
+++ b/src/runners/connectors_runner.py
@@ -3,6 +3,7 @@
  SAIR processes Data Connections in *_CONNECTION tables
 
 """
+import fire
 
 from multiprocessing import Pool
 from datetime import datetime
@@ -76,4 +77,4 @@ def main(connection_table="%_CONNECTION"):
 
 
 if __name__ == "__main__":
-    main()
+    fire.Fire(main)


### PR DESCRIPTION
Allows for quicker local testing of connectors. Tested by running

`python runners/connectors_runner.py --connection-table="OKTA_%"`