### PR TITLE
Cloudtrail Try Cast Boolean Value for MFA

### DIFF
--- a/src/connectors/aws_cloudtrail.py
+++ b/src/connectors/aws_cloudtrail.py
@@ -243,7 +243,7 @@ SELECT CURRENT_TIMESTAMP() insert_time
     , value:userIdentity.invokedBy::STRING user_identity_invokedby
     , value:userIdentity.accessKeyId::STRING user_identity_access_key_id
     , value:userIdentity.userName::STRING user_identity_username
-    , value:userIdentity.sessionContext.attributes.mfaAuthenticated::STRING user_identity_session_context_attributes_mfa_authenticated
+    , TRY_CAST(value:userIdentity.sessionContext.attributes.mfaAuthenticated::STRING AS BOOLEAN) user_identity_session_context_attributes_mfa_authenticated
     , value:userIdentity.sessionContext.attributes.creationDate::STRING user_identity_session_context_attributes_creation_date
     , value:userIdentity.sessionContext.sessionIssuer.type::STRING user_identity_session_context_session_issuer_type
     , value:userIdentity.sessionContext.sessionIssuer.principalId::STRING user_identity_session_context_session_issuer_principal_id


### PR DESCRIPTION
We are getting some values of 'unavailable' for our `value:userIdentity.sessionContext.attributes.mfaAuthenticated` column which is creating an error. TYPE_CAST helps prevent an error from occurring and replaces value with `NULL` if the TYPE_CAST doesn't recognize value.