### PR TITLE
Fix AssetPanda paging

### DIFF
--- a/src/connectors/assetpanda.py
+++ b/src/connectors/assetpanda.py
@@ -14,7 +14,7 @@ from runners.helpers.dbconfig import ROLE as SA_ROLE
 
 from .utils import yaml_dump
 
-# 50 is the max page size supported by the AssetPanda API for this endpoints currently.
+# 50 is the max page size supported by the AssetPanda API for this endpoint currently.
 PAGE_SIZE = 50
 
 CONNECTION_OPTIONS = [

--- a/src/connectors/assetpanda.py
+++ b/src/connectors/assetpanda.py
@@ -14,8 +14,8 @@ from runners.helpers.dbconfig import ROLE as SA_ROLE
 
 from .utils import yaml_dump
 
-
-PAGE_SIZE = 1000
+# 50 is the max page size supported by the AssetPanda API for this endpoints currently.
+PAGE_SIZE = 50
 
 CONNECTION_OPTIONS = [
     {


### PR DESCRIPTION
The max pagesize supported at the API is only 50 records. Using a pagesize any higher will skip records as an offset is used. 