### PR TITLE
fix:dc:aws_collect: Cartesian product between methods and accounts works correctly now

### DIFF
--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1107,9 +1107,6 @@ async def aioingest(table_name, options):
         'organizations.list_accounts', accounts, table_name=f'data.{table_name}'
     )
 
-    # Only collect for ACTIVE accounts
-    accounts = filter(lambda a: a.get('status') == 'ACTIVE', accounts)
-
     methods = [
         'iam.generate_credential_report',
         'iam.list_account_aliases',


### PR DESCRIPTION
For some reason, the previous code would only the combination of the first method for all accounts. 
This fix should take `methods X accounts`.