### PR TITLE
Allow OAuth connection parameter overrides

### DIFF
--- a/docs/src/pages/authentication.rst
+++ b/docs/src/pages/authentication.rst
@@ -56,6 +56,13 @@ would be DEMO (note the upper-case). i.e.:
     1. OAUTH_CLIENT_MYDEMO
     2. OAUTH_SECRET_MYDEMO
 
+4. (Optional) By default, OAuth tokens are granted to the user's default role, and the SnowAlert WebUI backend will use the user's default database and warehouse when running queries.
+To override this behaviour, there are three additional environment variables you can set:
+
+- ``OAUTH_CONNECTION_ROLE`` specifies the role to assume during all OAuth authorization flows (case sensitive).
+- ``OAUTH_CONNECTION_DATABASE`` specifies the database to use for all SQL queries.
+- ``OAUTH_CONNECTION_WAREHOUSE`` specifies the warehouse to use for all SQL queries.
+
 Server-side authentication
 --------------------------
 Snowflake OAuth is the recommended authentication method for the WebUI. Storing credentials in the following environment variables will enable anyone with web access to manage the rules and data connectors. Please don't use these environment variables in production. While we recommend using OAuth for prod auth, locally or in an otherwise secured environment, you can configure the application to use the same credentials stored in environment variables as the runners do: ``SNOWFLAKE_ACCOUNT``, ``SA_USER``, ``SA_ROLE``, ``SA_DATABASE``, ``SA_WAREHOUSE``, ``PRIVATE_KEY``, ``PRIVATE_KEY_PASSWORD``.

--- a/src/webui/backend/webui/api/oauth.py
+++ b/src/webui/backend/webui/api/oauth.py
@@ -11,6 +11,11 @@ logger = logbook.Logger(__name__)
 
 oauth_api = Blueprint('oauth', __name__)
 
+OAUTH_CONNECTION_ROLE=environ.get('OAUTH_CONNECTION_ROLE', None)
+if OAUTH_CONNECTION_ROLE:
+    scope_role=f' session:role:{OAUTH_CONNECTION_ROLE}'
+else:
+    scope_role=''
 
 @oauth_api.route('/redirect', methods=['POST'])
 def oauth_redirect():
@@ -28,7 +33,7 @@ def oauth_redirect():
             {
                 'client_id': OAUTH_CLIENT_ID,
                 'response_type': 'code',
-                'scope': 'refresh_token',
+                'scope': f'refresh_token{scope_role}',
                 'redirect_uri': returnHref,
             }
         )


### PR DESCRIPTION
This PR is in relation to issue #367.

The broad intent of this PR is to allow Snowflake users to access SnowAlert without needing to adjust their default user parameters. 

The suggestion by @andrey-snowflake in the issue would provide the most flexible solution for the user, but would only address Database and Warehouse selection. Because Role must be included in the OAuth request I don't think it could be provided as a selection.

So this backwards compatible change introduces three new optional environment variables that apply only to OAuth connections, and they allow manual setting of Role, Database and Warehouse.

It is a low effort, low risk change at the cost of flexibility - it means that to leverage this new setting, all users on the WebUI must use the same Snowflake Role, which I think is a reasonable requirement.

In future, it should still be possible to implement choice of Database and Warehouse in the UI without clashing with this change. If OAUTH_CONNECTION_DATABASE and/or OAUTH_CONNECTION_WAREHOUSE are defined then they can be the defaults.

