### PR TITLE
Cloudformation template fixes

### DIFF
--- a/infra/cfn/CLOUDFORMATION.md
+++ b/infra/cfn/CLOUDFORMATION.md
@@ -15,27 +15,31 @@ Prerequisites:
 ```
 /SnowAlert/master/PRIVATE_KEY
 /SnowAlert/master/PRIVATE_KEY_PASSWORD
-/SnowAlert/master/SA_USER
-/SnowAlert/master/SA_WAREHOUSE
-/SnowAlert/master/SA_DATABASE
-/SnowAlert/master/SA_ROLE
 /SnowAlert/master/SLACK_API_TOKEN
-/SnowAlert/master/SNOWFLAKE_ACCOUNT
+/SnowAlert/master/JIRA_PASSWORD
+/SnowAlert/master/OAUTH_CLIENT_(snowflake_account_id)
+/SnowAlert/master/OAUTH_SECRET_(snowflake_account_id)
 ```
+_Note: The (snowflake_account_id) suffix from those last two parameters is set by the SnowflakeAccount cloudformation parameter_
+
+For optional parameters like `SLACK_API_TOKEN` and `JIRA_PASSWORD`, you must still set them but just leave them blank. ECS does not support optional secrets and Cloudformation cannot provide them conditionally.
+
+The remaining non-sensitive parameters (`SA_USER`,`SA_WAREHOUSE`,`SA_DATABASE`,`SA_ROLE`,`SNOWFLAKE_ACCOUNT`,`JIRA_USER`,`JIRA_URL`,`JIRA_PROJECT`) are configured as regular environment variables fed by Cloudformation parameters.
 
 Assuming the AWS CLI has been configured with default region and credentials, for a role similar to Power User, you can provision the stack from the commandline like so.
 
 No Web UI:
 ```
-aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=DeployWebUi,ParameterValue=false
+aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=DeployWebUi,ParameterValue=false ParameterKey=SnowflakeAccount,ParameterValue=ab1234567 
 ```
 
 With Web UI, internal VPC access only:
 ```
-aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=CertificateArn,ParameterValue=arn:aws:acm:ap-southeast-2:123456789012:certificate/461b5dc1-443c-46ef-a5df-a6e6a7190d67 ParameterKey=InstanceFqdn,ParameterValue=snowalert.myinternaldomain.com ParameterKey=InstanceHostedZone,ParameterValue=myinternaldomain.com. 
+aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=CertificateArn,ParameterValue=arn:aws:acm:ap-southeast-2:123456789012:certificate/461b5dc1-443c-46ef-a5df-a6e6a7190d67 ParameterKey=InstanceFqdn,ParameterValue=snowalert.myinternaldomain.com ParameterKey=InstanceHostedZone,ParameterValue=myinternaldomain.com. ParameterKey=SnowflakeAccount,ParameterValue=ab1234567 
 ```
 
-With Web UI, public facing:
+With Web UI, public facing and including Jira integration:
 ```
-aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=CertificateArn,ParameterValue=arn:aws:acm:ap-southeast-2:123456789012:certificate/461b5dc1-443c-46ef-a5df-a6e6a7190d67 ParameterKey=InstanceFqdn,ParameterValue=snowalert.mydomain.com ParameterKey=InstanceHostedZone,ParameterValue=mydomain.com. ParameterKey=WebUiAlbScheme,ParameterValue=internet-facing
+aws cloudformation create-stack --template-body snowalert.yaml --stack-name SnowAlert-Prod --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=Vpc,ParameterValue=vpc-a1234567 ParameterKey=SubnetOne,ParameterValue=subnet-1ab23456 ParameterKey=SubnetTwo,ParameterValue=subnet-2cd34567 ParameterKey=CertificateArn,ParameterValue=arn:aws:acm:ap-southeast-2:123456789012:certificate/461b5dc1-443c-46ef-a5df-a6e6a7190d67 ParameterKey=InstanceFqdn,ParameterValue=snowalert.mydomain.com ParameterKey=InstanceHostedZone,ParameterValue=mydomain.com. ParameterKey=WebUiAlbScheme,ParameterValue=internet-facing ParameterKey=SnowflakeAccount,ParameterValue=ab1234567 ParameterKey=SnowAlertJiraUser,ParameterValue=snowalertuser ParameterKey=SnowAlertJiraUrl,ParameterValue=https://mydomain.atlassian.net/ ParameterKey=SnowAlertJiraProject,ParameterValue=SA 
 ```
+

--- a/infra/cfn/snowalert.yaml
+++ b/infra/cfn/snowalert.yaml
@@ -63,6 +63,39 @@ Parameters:
     Type: String
     Default: "master"
     Description: Used to differentiate between multiple deployments within the one account, e.g. a test AWS account supporting multiple branch builds
+  SnowflakeAccount:
+    Type: String
+    Default: ""
+    Description: If deploying the Web UI, used to build the OAUTH_CLIENT_(account) and OAUTH_SECRET_(account) environment variables for the container. Must be just your Snowflake account id, e.g. "AB1234567", and per the SnowAlert documentation it must be uppercase.
+  SnowAlertDatabase:
+    Type: String
+    Default: "snowalert"
+    Description: Sets the SA_DATABASE environment variable for SnowAlert per https://snowalert.readthedocs.io/en/latest/pages/start.html#installing
+  SnowAlertUser:
+    Type: String
+    Default: "snowalert"
+    Description: Sets the SA_USER environment variable for SnowAlert per https://snowalert.readthedocs.io/en/latest/pages/start.html#installing
+  SnowAlertWarehouse:
+    Type: String
+    Default: "compute_wh"
+    Description: Sets the SA_WAREHOUSE environment variable for SnowAlert per https://snowalert.readthedocs.io/en/latest/pages/start.html#installing
+  SnowAlertRole:
+    Type: String
+    Default: "snowalert"
+    Description: Sets the SA_ROLE environment variable for SnowAlert per https://snowalert.readthedocs.io/en/latest/pages/start.html#installing
+  SnowAlertJiraUser:
+    Type: String
+    Default: ""
+    Description: Sets the Jira user, leave blank to disable Jira alerting
+  SnowAlertJiraUrl:
+    Type: String
+    Default: ""
+    Description: Sets the Jira Url, leave blank to disable Jira alerting
+  SnowAlertJiraProject:
+    Type: String
+    Default: ""
+    Description: Sets the Jira Project Key, leave blank to disable Jira alerting
+
 Conditions:
   ShouldCreateWebUi:
     !Equals [true, !Ref DeployWebUi]
@@ -88,7 +121,7 @@ Resources:
       Targets:
       - Arn: !GetAtt AlertsECSCluster.Arn
         Id: !Join ["-",[!Ref 'ResourcesPrefix', !Ref 'Slice', 'FargateTask'] ]
-        RoleArn: !GetAtt SnowAlertTaskExecutionRole.Arn
+        RoleArn: !GetAtt SnowAlertRunTaskRole.Arn
         EcsParameters:
           TaskDefinitionArn: !Ref AlertsTaskDefinition
           TaskCount: 1
@@ -153,6 +186,7 @@ Resources:
           - Effect: Allow
             Action:
             - kms:Decrypt
+            - kms:Encrypt
             Resource: !GetAtt SnowAlertKmsKey.Arn
       Roles:
         - !Ref 'SnowAlertTaskExecutionRole'
@@ -182,7 +216,7 @@ Resources:
           - Effect: Allow
             Action:
             - ecs:RunTask
-            Resource: !GetAtt AlertsECSCluster.Arn
+            Resource: !Ref 'AlertsTaskDefinition'
             Condition:
               ArnLike:
                 ecs:cluster: !GetAtt AlertsECSCluster.Arn
@@ -223,7 +257,7 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ExecutionRoleArn: !Ref 'SnowAlertTaskExecutionRole'
-      TaskRoleArn: !Ref 'SnowAlertRunTaskRole'
+      TaskRoleArn: !Ref 'SnowAlertTaskExecutionRole'
       ContainerDefinitions:
         - Name: !Join ["-",[!Ref 'ResourcesPrefix', !Ref 'Slice', 'AlertsECSService'] ]
           Cpu: !Ref 'AlertsContainerCpu'
@@ -233,7 +267,7 @@ Resources:
             - sh
             - -c
             - |
-              ./run alerts
+              ./run all
           Environment:
             - Name: REGION
               Value: !Ref 'AWS::Region'
@@ -241,23 +275,33 @@ Resources:
               Value: 'True'
             - Name: SA_KMS_KEY
               Value: !GetAtt SnowAlertKmsKey.Arn
+            - Name: SA_KMS_REGION
+              Value: !Ref 'AWS::Region'
+            - Name: SNOWFLAKE_ACCOUNT
+              Value: !Ref 'SnowflakeAccount'
+            - Name: SA_DATABASE
+              Value: !Ref 'SnowAlertDatabase'
+            - Name: SA_USER
+              Value: !Ref 'SnowAlertUser'
+            - Name: SA_WAREHOUSE
+              Value: !Ref 'SnowAlertWarehouse'
+            - Name: SA_ROLE
+              Value: !Ref 'SnowAlertRole'
+            - Name: JIRA_USER
+              Value: !Ref 'SnowAlertJiraUser'
+            - Name: JIRA_URL
+              Value: !Ref 'SnowAlertJiraUrl'
+            - Name: JIRA_PROJECT
+              Value: !Ref 'SnowAlertJiraProject'
           Secrets:
             - Name: PRIVATE_KEY
               ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','PRIVATE_KEY']]]]
             - Name: PRIVATE_KEY_PASSWORD
               ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','PRIVATE_KEY_PASSWORD']]]]
-            - Name: SA_USER
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SA_USER']]]]
-            - Name: SA_WAREHOUSE
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SA_WAREHOUSE']]]]
-            - Name: SA_DATABASE
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SA_DATABASE']]]]
-            - Name: SA_ROLE
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SA_ROLE']]]]
             - Name: SLACK_API_TOKEN
               ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SLACK_API_TOKEN']]]]
-            - Name: SNOWFLAKE_ACCOUNT
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SNOWFLAKE_ACCOUNT']]]]
+            - Name: JIRA_PASSWORD
+              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','JIRA_PASSWORD']]]]
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -344,7 +388,7 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ExecutionRoleArn: !Ref 'SnowAlertTaskExecutionRole'
-      #TaskRoleArn: !Ref 'SnowAlertRunTaskRole'
+      TaskRoleArn: !Ref 'SnowAlertTaskExecutionRole'
       ContainerDefinitions:
         - Name: !Join ["-",[!Ref 'ResourcesPrefix', !Ref 'Slice', 'WebUiECSService'] ]
           Cpu: !Ref 'WebUiContainerCpu'
@@ -357,15 +401,23 @@ Resources:
           Environment:
             - Name: REGION
               Value: !Ref 'AWS::Region'
+            - Name: SA_KMS_REGION
+              Value: !Ref 'AWS::Region'
             - Name: CLOUDWATCH_METRICS
               Value: 'True'
             - Name: SA_KMS_KEY
               Value: !GetAtt SnowAlertKmsKey.Arn
+            - Name: SNOWFLAKE_ACCOUNT
+              Value: !Ref 'SnowflakeAccount'
+            - Name: SA_DATABASE
+              Value: !Ref 'SnowAlertDatabase'
           Secrets:
             - Name: SLACK_API_TOKEN
               ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SLACK_API_TOKEN']]]]
-            - Name: SNOWFLAKE_ACCOUNT
-              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SNOWFLAKE_ACCOUNT']]]]
+            - Name: !Join ["_",['OAUTH_CLIENT',!Ref 'SnowflakeAccount'] ]
+              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SNOWALERT_OAUTH_CLIENT']]]]
+            - Name: !Join ["_",['OAUTH_SECRET',!Ref 'SnowflakeAccount'] ]
+              ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SNOWALERT_OAUTH_SECRET']]]]
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/infra/cfn/snowalert.yaml
+++ b/infra/cfn/snowalert.yaml
@@ -95,6 +95,18 @@ Parameters:
     Type: String
     Default: ""
     Description: Sets the Jira Project Key, leave blank to disable Jira alerting
+  SnowAlertOAuthConnectionRole:
+    Type: String
+    Default: ""
+    Description: If deploying the Web UI, specifies the role to assume during all OAuth authorization flows (case sensitive).
+  SnowAlertOAuthConnectionDatabase:
+    Type: String
+    Default: ""
+    Description: If deploying the Web UI, specifies the database to assume during all OAuth authorization flows (case sensitive).
+  SnowAlertOAuthConnectionWarehouse:
+    Type: String
+    Default: ""
+    Description: If deploying the Web UI, specifies the warehouse to assume during all OAuth authorization flows (case sensitive).
 
 Conditions:
   ShouldCreateWebUi:
@@ -411,6 +423,12 @@ Resources:
               Value: !Ref 'SnowflakeAccount'
             - Name: SA_DATABASE
               Value: !Ref 'SnowAlertDatabase'
+            - Name: OAUTH_CONNECTION_ROLE
+              Value: !Ref 'SnowAlertOAuthConnectionRole'
+            - Name: OAUTH_CONNECTION_DATABASE
+              Value: !Ref 'SnowAlertOAuthConnectionDatabase'
+            - Name: OAUTH_CONNECTION_WAREHOUSE
+              Value: !Ref 'SnowAlertOAuthConnectionWarehouse'
           Secrets:
             - Name: SLACK_API_TOKEN
               ValueFrom: !Join [':', ['arn:aws:ssm', !Ref 'AWS::Region', !Ref 'AWS::AccountId',!Join ['/', [ 'parameter', !Ref ResourcesPrefix, !Ref 'Slice','SLACK_API_TOKEN']]]]


### PR DESCRIPTION
This PR:
- Fixes a couple of issues with the alert container in the Cloudformation template (IAM-related and the shell command)
- Moves all of the non-sensitive parameters out of SSM and into regular template parameters
- Adds support for Jira integration to the Cloudformation template
- Adds support for the new WebUI OAuth connection parameter overrides to the Cloudformation template

