### PR TITLE
Fix slack template selector not using params

### DIFF
--- a/src/runners/handlers/slack.py
+++ b/src/runners/handlers/slack.py
@@ -28,7 +28,8 @@ def message_template(vars):
     try:
         # retrieve Slack message structure from javascript UDF
         rows = db.connect_and_fetchall(
-            "select " + vars['template'] + "(parse_json('" + json.dumps(params) + "'))"
+            "select " + vars['template'] + "(parse_json(%s))",
+            params=[json.dumps(params)]
         )
         row = rows[1]
 


### PR DESCRIPTION
If the JSON contains a single quote then things blow up.