### PR TITLE
add logic to re-run unsuccessful handlers

### DIFF
--- a/src/runners/alert_dispatcher.py
+++ b/src/runners/alert_dispatcher.py
@@ -8,8 +8,10 @@ from .utils import apply_some, json_dumps
 
 GET_ALERTS_QUERY = f"""
 SELECT *
-FROM results.alerts
-WHERE IFF(alert:HANDLERS IS NULL, ticket IS NULL, handled IS NULL)
+FROM results.alerts a1
+WHERE IFF(alert:HANDLERS IS NULL, ticket IS NULL, handled IS NULL or 
+           (select count(*) from results.alerts a2, lateral flatten(input => handled)
+               where a2.correlation_id = a1.correlation_id and value:success::boolean = FALSE) > 0)
   AND suppressed=FALSE
 ORDER BY event_time ASC
 LIMIT 1000
@@ -37,52 +39,64 @@ def main():
 
     for alert_row in alert_rows:
         alert = alert_row['ALERT']
+
+        handled = alert_row['HANDLED']
+        if handled:
+            log.info(f'Found failed handle attempt for correlation ID {alert_row["CORRELATION_ID"]}')
+
         results = []
 
         handlers = alert.get('HANDLERS')
+        handler_index = 0
         for handler in ['jira'] if handlers is None else handlers:
             if handler is None:
                 results.append(None)
 
             else:
-                if type(handler) is str:
-                    handler = {'type': handler}
-
-                if 'type' not in handler:
-                    result = {
-                        'success': False,
-                        'error': 'missing type key',
-                        'details': handler,
-                    }
-
+                if handled and handled[handler_index]['success']:
+                    log.info(f'Skipping previously successful handler {handler}')
+                    results.append(handled[handler_index])
                 else:
-                    handler_type = handler['type']
+                    if type(handler) is str:
+                        handler = {'type': handler}
 
-                    handler_kwargs = handler.copy()
-                    handler_kwargs.update(
-                        {
-                            'alert': alert,
-                            'correlation_id': alert_row.get('CORRELATION_ID'),
-                            'alert_count': alert_row['COUNTER'],
-                        }
-                    )
-
-                    try:
-                        handler_module = importlib.import_module(
-                            f'runners.handlers.{handler_type}'
-                        )
+                    if 'type' not in handler:
                         result = {
-                            'success': True,
-                            'details': apply_some(
-                                handler_module.handle, **handler_kwargs
-                            ),
+                            'success': False,
+                            'error': 'missing type key',
+                            'details': handler,
                         }
 
-                    except Exception as e:
-                        log.error(e, 'handler failed')
-                        result = {'success': False, 'details': e}
+                    else:
+                        handler_type = handler['type']
 
-                results.append(result)
+                        handler_kwargs = handler.copy()
+                        handler_kwargs.update(
+                            {
+                                'alert': alert,
+                                'correlation_id': alert_row.get('CORRELATION_ID'),
+                                'alert_count': alert_row['COUNTER'],
+                            }
+                        )
+
+                        try:
+                            handler_module = importlib.import_module(
+                                f'runners.handlers.{handler_type}'
+                            )
+                            result = {
+                                'success': True,
+                                'details': apply_some(
+                                    handler_module.handle, **handler_kwargs
+                                ),
+                            }
+
+                        except Exception as e:
+                            log.error(e, 'handler failed')
+                            result = {'success': False, 'details': e}
+
+                    results.append(result)
+
+            handler_index += 1
 
         record_status(results, alert['ALERT_ID'])
 


### PR DESCRIPTION
I've added logic to retry handlers where `success = false`.

Before this, an error in a handler (in my case, errors not correctly handled by the slack handler, which I will submit a PR for shortly) would result in an entry in `alerts.HANDLED`, which would prevent that alert from ever being handled again.

The solution would be to set `alerts.HANDLED` to `NULL`, but that's not a great option when you have multiple handlers, and the other handlers succeeded. It's also not preferable to have that manual step in general.

This change extends the query to return every unhandled alert, and also any alert with a failed handler. In the latter case, it will skip successful handlers and only retry the failed ones.

The result is that a fix for the error (for example, fixing that slack error where the json string was not escaped properly, and single quotes broke the query, or fixing some error in the UDF itself) will result in just the failed the handler being fired on the next run.