### PR TITLE
Bugfix/slack error handling

### DIFF
--- a/src/runners/handlers/slack.py
+++ b/src/runners/handlers/slack.py
@@ -105,10 +105,7 @@ def handle(
         properties = {'channel': channel, 'message': message}
 
         # create Slack message structure in Snowflake javascript UDF
-        try:
-            payload = message_template(locals())
-        except Exception:
-            return None
+        payload = message_template(locals())
 
         if payload is not None:
             if 'blocks' in payload:

--- a/src/runners/handlers/slack.py
+++ b/src/runners/handlers/slack.py
@@ -38,7 +38,7 @@ def message_template(vars):
             payload = json.loads(''.join(row[0]))
         else:
             log.error(f"Error loading javascript template {vars['template']}")
-            raise Exception("Error loading javascript template " + {vars['template']})
+            raise Exception(f"Error loading javascript template {vars['template']}")
     except Exception as e:
         log.error(f"Error loading javascript template", e)
         raise


### PR DESCRIPTION
This fixes two issues with how the Slack handler handles errors.

The first is a fix for the Exception message formatting, which resulted in a string concatenation error before, and the raised exception was actually this one, not the original exception. Now it uses string templates properly and raises the intended exception.

The second fix is to let any error with the UDF propagate up to the calling function, instead of returning `None`.

Before, catching this exception and returning `None` would result in alert_dispatcher thinking the handler completed successfully; it would set
```
result = {
  'success': True,
  'details': apply_some(handler_module.handle, **handler_kwargs),
}
```
where the return value of `apply_some(...)` was `None`.

This fix raises the exception up so that the `result` includes `success: False` and the exception that caused it.