### PR TITLE
add explicit 'from time' argument; defend from SQL injection

### DIFF
--- a/src/runners/alert_queries_runner.py
+++ b/src/runners/alert_queries_runner.py
@@ -28,7 +28,7 @@ from runners.helpers import db, log
 # - SA_ALERT_CUTOFF_MINUTES=x: use the last x minutes.
 # - SA_ALERT_FROM_TIME=x: use the window from x to now.
 # - SA_ALERT_TO_TIME=x: use the 90 minutes before / up to x.
-# - SA_ALERT_TO_TIME=x, SA_ALERT_CUTOFF_MINUTES=y: use the y minutes before / up to x.
+# - SA_ALERT_CUTOFF_MINUTES=x, SA_ALERT_TO_TIME=y: use the x minutes before / up to y.
 # - SA_ALERT_FROM_TIME=x, SA_ALERT_TO_TIME=y: use the window x to y.
 
 # We'll also do some simple checks to prevent against SQL injections, since these values will be inserted as-is into

--- a/src/runners/alert_queries_runner.py
+++ b/src/runners/alert_queries_runner.py
@@ -2,7 +2,6 @@
 
 import datetime
 import os
-import pytz
 from multiprocessing import Pool
 from typing import Any, Dict
 

--- a/src/runners/alert_queries_runner.py
+++ b/src/runners/alert_queries_runner.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+import pytz
 from multiprocessing import Pool
 from typing import Any, Dict
 
@@ -16,9 +17,53 @@ from runners.config import (
 from runners.helpers import db, log
 
 
-ALERT_CUTOFF_MINUTES = os.environ.get('SA_ALERT_CUTOFF_MINUTES', -90)
-ALERTS_TO_TIME = os.environ.get('SA_ALERT_TO_TIME', 'CURRENT_TIMESTAMP')
-ALERTS_FROM_TIME = f"DATEADD(minute, {ALERT_CUTOFF_MINUTES}, {ALERTS_TO_TIME})"
+# There are three time window properties that will be combined in different ways depending on which are present.
+# - SA_ALERT_FROM_TIME: a timestamp specifying the start of the window. If omitted, use SA_ALERT_CUTOFF_MINUTES relative
+# to SA_ALERT_TO_TIME.
+# - SA_ALERT_TO_TIME: a timestamp specifying the end of the window. If omitted, use the current timestamp.
+# - SA_ALERT_CUTOFF_MINUTES: the length of the window relative to SA_ALERT_TO_TIME; only used if SA_ALERT_FROM_TIME is
+# not present. Defaults to 90.
+#
+# So, the possible combinations to specify a window are:
+# - All options omitted: use the last 90 minutes.
+# - SA_ALERT_CUTOFF_MINUTES=x: use the last x minutes.
+# - SA_ALERT_FROM_TIME=x: use the window from x to now.
+# - SA_ALERT_TO_TIME=x: use the 90 minutes before / up to x.
+# - SA_ALERT_TO_TIME=x, SA_ALERT_CUTOFF_MINUTES=y: use the y minutes before / up to x.
+# - SA_ALERT_FROM_TIME=x, SA_ALERT_TO_TIME=y: use the window x to y.
+
+# We'll also do some simple checks to prevent against SQL injections, since these values will be inserted as-is into
+# the query.
+
+# TODO this should probably be moved to a method, but there may be other logic that depends on these global variables
+# or the fact that this would only be executed once on import in its current location (as opposed to calling an
+# initialization method from the main method which could end up getting repeated, for example).
+
+ALERT_CUTOFF_MINUTES = int(os.environ.get('SA_ALERT_CUTOFF_MINUTES', -90))
+if ALERT_CUTOFF_MINUTES > 0:
+    ALERT_CUTOFF_MINUTES = -ALERT_CUTOFF_MINUTES
+
+timestamp_format = '%Y-%m-%d %H:%M:%S.%f'
+
+# Get a single, consistent timestamp to use for the "to" time that will be the same for every alert query.
+# This will return a timestamp_tz that will be compatible with any timestamp_ntz queries that also run,
+# as it will be in the DB's default TZ.
+current_timestamp_from_db = db.execute('select current_timestamp::string').fetchall()[0][0]
+
+ALERTS_TO_TIME = os.environ.get('SA_ALERT_TO_TIME')
+if ALERTS_TO_TIME:
+    datetime.datetime.strptime(ALERTS_TO_TIME, timestamp_format)  # this just ensures the date string is valid
+    ALERTS_TO_TIME = f"'{ALERTS_TO_TIME}'"
+else:
+    ALERTS_TO_TIME = f"'{current_timestamp_from_db}'"
+
+ALERTS_FROM_TIME = os.environ.get('SA_ALERT_FROM_TIME')
+if ALERTS_FROM_TIME:
+    datetime.datetime.strptime(ALERTS_FROM_TIME, timestamp_format)
+    ALERTS_FROM_TIME = f"'{ALERTS_FROM_TIME}'"
+else:
+    ALERTS_FROM_TIME = f"DATEADD(minute, {ALERT_CUTOFF_MINUTES}, {ALERTS_TO_TIME})"
+
 
 RUN_ALERT_QUERY = f"""
 CREATE TRANSIENT TABLE results.RUN_{RUN_ID}_{{query_name}} AS


### PR DESCRIPTION
This change adds a few small features:

1. Explicit support for an `SA_ALERT_FROM_TIME` environment variable when the user would rather specify a given range instead of an end time and cutoff period
2. Proper handling of arguments to prevent SQL injection
3. Locking the "to" time to a consistent timestamp fur the duration of the run

**1. Support for "from time"**

An example use case is for automated periodic runs while ensuring an error does not result in a missed window. For example, say the normal execution of the task is hourly and looks at alerts from the last hour. Upon successful completion of the task, it can update the `alert_from_time` to be the previous run's `alert_to_time`. If the task fails, then the old `alert_from_time` will remain, and the next run of the task will include the "missed" window.

**2. SQL injection prevention**

Arguments are validated using formatting rules. The cutoff minutes value is converted to an int; timestamps are checked using `strftime`. If any of these validations fails, then the arguments are invalid. This also makes the job fail before running any alert queries, making errors in the input values easier to detect.

**3. Consistent timestamp**

Instead of inserting `CURRENT_TIMESTAMP` into a query if no "to time" is given, this change gets the current timestamp at the start of the run, and then inserts it into each query. This ensures each alert query runs over the exact same window, avoiding the case where a long-running alert query can throw off the time window of subsequent alert queries.

Note that this logic is now convoluted enough that it should probably be refactored into a helper or utility method. I do have other code that reuses these global variables once they are set, and I am not 100% sure that there is no other logic that relies on this code running once, so I left the structure as-is.
