### PR TITLE
fix timezones in cloudtrail event_time column

### DIFF
--- a/src/connectors/aws_cloudtrail.py
+++ b/src/connectors/aws_cloudtrail.py
@@ -207,7 +207,7 @@ SELECT CURRENT_TIMESTAMP() insert_time
     --- In the rare event of an unparsable timestamp, the following COALESCE keeps the pipeline from failing.
     --- Compare event_time to TRY_TO_TIMESTAMP(raw:eventTime::STRING) to establish if the timestamp was parsed.
     , COALESCE(
-        TRY_TO_TIMESTAMP(value:eventTime::STRING)::TIMESTAMP_LTZ(9),
+        TRY_TO_TIMESTAMP_LTZ(value:eventTime::STRING),
         CURRENT_TIMESTAMP()
       ) event_time
     , value:awsRegion::STRING aws_region


### PR DESCRIPTION
I've fixed a bug in the timestamps on the event_time column in the AWS CloudTrail logs.  

**Finding the bug:**
I noticed the bug by running this query on the CloudTrail logs:
```
SELECT CURRENT_TIMESTAMP, MAX(EVENT_TIME) AS MAX_EVENT_TIME
FROM DATA.AWS_CLOUDTRAIL_DEFAULT_EVENTS_CONNECTION;
```
The result of the query was:
![image](https://user-images.githubusercontent.com/29736845/87724499-9572d800-c789-11ea-83a3-a68a5895f3af.png)

As can be seen in the query result, the latest event_time value is later than the current time, and both are marked as in the same timezone (-0700).  No events could be logging that occurred in the future, so something had to be wrong with the timezones.

**Fixing the bug:**
I suspected that the casting of the timestamp to the local time zone in the existing code was introducing the bug.  I tested this using a raw event time value as input with this query, which contains the existing code without the cast as one column and with the cast as another column:
```
SELECT 
    TRY_TO_TIMESTAMP('2020-06-15T23:47:54Z') AS TIMESTAMP_NO_CAST,
    TRY_TO_TIMESTAMP('2020-06-15T23:47:54Z')::TIMESTAMP_LTZ(9) AS TIMESTAMP_CAST_LTZ;
```
The result of the query was:
![image](https://user-images.githubusercontent.com/29736845/87725281-fe0e8480-c78a-11ea-817f-7443ca6af53c.png)

As can be seen in the query result, the cast to TIMESTAMP_LTZ(9) adds the -0700 timezone to the timestamp, but it *does not* change the hour of the entry to coincide with changing the timezone.  

Using the TRY_TO_TIMESTAMP_LTZ function has the desired result: the local timezone is applied to the timestamp, and the hour of the timestamp is adjusted based on the local timezone. 

This query was used to test the fix alongside the results of the previous query; results are below:
```
SELECT 
    TRY_TO_TIMESTAMP('2020-06-15T23:47:54Z') AS TIMESTAMP_NO_CAST,
    TRY_TO_TIMESTAMP('2020-06-15T23:47:54Z')::TIMESTAMP_LTZ(9) AS TIMESTAMP_CAST_LTZ, 
    TRY_TO_TIMESTAMP_LTZ('2020-06-15T23:47:54Z') AS TIMESTAMP_LTZ_FIX;
```

![image](https://user-images.githubusercontent.com/29736845/87725417-49c12e00-c78b-11ea-935e-40dc9e9460c3.png)
