### PR TITLE
[DC] Add aws_collect s3.get_public_access_block

### DIFF
--- a/migrations/v1_9_6-v1_10_0.md
+++ b/migrations/v1_9_6-v1_10_0.md
@@ -12,7 +12,7 @@ CREATE OR REPLACE TABLE azure_collect_network_interfaces (
     location STRING,
     properties VARIANT,
     tags VARIANT,
-    type STRING,
+    type STRING
 );
 GRANT SELECT, INSERT
 ON azure_collect_network_interfaces
@@ -25,12 +25,12 @@ TO ROLE snowalert;
 CREATE OR REPLACE TABLE data.aws_collect_s3_get_public_access_block (
     recorded_at TIMESTAMP_LTZ,
     account_ID STRING,
-    error VARIANT,
     bucket STRING,
+    error VARIANT,
     ignore_public_acls BOOLEAN,
     block_public_policy BOOLEAN,
     block_public_acls BOOLEAN,
-    restrict_public_buckets BOOLEAN,
+    restrict_public_buckets BOOLEAN
 );
 GRANT SELECT, INSERT
 ON data.aws_collect_s3_get_public_access_block

--- a/migrations/v1_9_6-v1_10_0.md
+++ b/migrations/v1_9_6-v1_10_0.md
@@ -18,3 +18,21 @@ GRANT SELECT, INSERT
 ON azure_collect_network_interfaces
 TO ROLE snowalert;
 ```
+
+# Update AWS Collect Landing Tables
+## S3 Get Public Blocks
+```sql
+CREATE OR REPLACE TABLE data.aws_collect_s3_get_public_access_block (
+    recorded_at TIMESTAMP_LTZ,
+    account_ID STRING,
+    error VARIANT,
+    bucket STRING,
+    ignore_public_acls BOOLEAN,
+    block_public_policy BOOLEAN,
+    block_public_acls BOOLEAN,
+    restrict_public_buckets BOOLEAN,
+);
+GRANT SELECT, INSERT
+ON data.aws_collect_s3_get_public_access_block
+TO ROLE snowalert;
+```

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -459,6 +459,17 @@ SUPPLEMENTARY_TABLES = {
         ('target_grants', 'VARIANT'),
         ('target_prefix', 'STRING'),
     ],
+    # https://docs.aws.amazon.com/cli/latest/reference/s3api/get-public-access-block.html
+    's3_get_public_access_block': [
+        ('recorded_at', 'TIMESTAMP_LTZ'),
+        ('account_id', 'STRING'),
+        ('error', 'VARIANT'),
+        ('bucket', 'STRING'),
+        ('ignore_public_acls', 'BOOLEAN'),
+        ('block_public_policy', 'BOOLEAN'),
+        ('block_public_acls', 'BOOLEAN'),
+        ('restrict_public_buckets', 'BOOLEAN'),
+    ],
     # https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/describe-trails.html#output
     'cloudtrail_describe_trails': [
         ('recorded_at', 'TIMESTAMP_LTZ'),
@@ -943,6 +954,7 @@ API_METHOD_SPECS: Dict[str, dict] = {
                     's3.get_bucket_acl',
                     's3.get_bucket_policy',
                     's3.get_bucket_logging',
+                    's3.get_public_access_block',
                 ],
                 'args': {'Bucket': 'bucket_name'},
             }
@@ -970,6 +982,17 @@ API_METHOD_SPECS: Dict[str, dict] = {
                 'TargetPrefix': 'target_prefix',
             }
         },
+    },
+    's3.get_public_access_block': {
+        'params': {'Bucket': 'bucket'},
+        'response': {
+            'PublicAccessBlockConfiguration': {
+                'IgnorePublicAcls': 'ignore_public_acls',
+                'BlockPublicPolicy': 'block_public_policy',
+                'BlockPublicAcls': 'block_public_acls',
+                'RestrictPublicBuckets': 'restrict_public_buckets',
+            }
+        }
     },
     'cloudtrail.describe_trails': {
         'response': {

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -463,11 +463,11 @@ SUPPLEMENTARY_TABLES = {
     's3_get_public_access_block': [
         ('recorded_at', 'TIMESTAMP_LTZ'),
         ('account_id', 'STRING'),
-        ('error', 'VARIANT'),
         ('bucket', 'STRING'),
+        ('error', 'VARIANT'),
+        ('block_public_acls', 'BOOLEAN'),
         ('ignore_public_acls', 'BOOLEAN'),
         ('block_public_policy', 'BOOLEAN'),
-        ('block_public_acls', 'BOOLEAN'),
         ('restrict_public_buckets', 'BOOLEAN'),
     ],
     # https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/describe-trails.html#output
@@ -987,9 +987,9 @@ API_METHOD_SPECS: Dict[str, dict] = {
         'params': {'Bucket': 'bucket'},
         'response': {
             'PublicAccessBlockConfiguration': {
+                'BlockPublicAcls': 'block_public_acls',
                 'IgnorePublicAcls': 'ignore_public_acls',
                 'BlockPublicPolicy': 'block_public_policy',
-                'BlockPublicAcls': 'block_public_acls',
                 'RestrictPublicBuckets': 'restrict_public_buckets',
             }
         }

--- a/src/connectors/tests/test_aws_collect.py
+++ b/src/connectors/tests/test_aws_collect.py
@@ -168,6 +168,9 @@ TEST_DATA_REQUEST_RESPONSE = [
                 account_id='1', method='s3.get_bucket_logging', args={'Bucket': 'name1'}
             ),
             CollectTask(
+                account_id='1', method='s3.get_bucket_access_block', args={'Bucket': 'name1'}
+            ),
+            CollectTask(
                 account_id='1', method='s3.get_bucket_acl', args={'Bucket': 'name2'}
             ),
             CollectTask(
@@ -175,6 +178,9 @@ TEST_DATA_REQUEST_RESPONSE = [
             ),
             CollectTask(
                 account_id='1', method='s3.get_bucket_logging', args={'Bucket': 'name2'}
+            ),
+            CollectTask(
+                account_id='1', method='s3.get_bucket_access_block', args={'Bucket': 'name2'}
             ),
         ],
     ),


### PR DESCRIPTION
Fixes https://github.com/snowflakedb/SnowAlert/issues/453

Tested by:
- running the migration sql script
- running `python runners/connectors_runner.py "AWS_COLLECT_%%"` locally (under snowalert snowflake role)
- `select * from data.aws_collect_s3_get_public_access_block;` 

One thing to note is that we'll get 404's and a corresponding `ClientError` for buckets with no public access block. 