### PR TITLE
Support oauth for snowflake deployments in non-default regions

### DIFF
--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -3,6 +3,8 @@ FROM python:3.7-slim-stretch
 WORKDIR /var/task
 
 RUN apt-get update
+RUN apt-get install -y r-base
+RUN R -e "install.packages(c('dplyr', 'purrr', 'tidyr','MASS', 'tidyverse', 'broom','testthat'), repos = 'https://cloud.r-project.org')"
 
 RUN pip install --upgrade pip virtualenv pyflakes
 

--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -3,8 +3,6 @@ FROM python:3.7-slim-stretch
 WORKDIR /var/task
 
 RUN apt-get update
-RUN apt-get install -y r-base
-RUN R -e "install.packages(c('dplyr', 'purrr', 'tidyr','MASS', 'tidyverse', 'broom','testthat'), repos = 'https://cloud.r-project.org')"
 
 RUN pip install --upgrade pip virtualenv pyflakes
 

--- a/src/runners/helpers/db.py
+++ b/src/runners/helpers/db.py
@@ -123,6 +123,7 @@ def connect(flush_cache=False, set_cache=False, oauth={}):
         if oauth_access_token
         else ROLE
     )
+    region = environ.get('REGION', 'us-west-2')
 
     def connect():
         return connect_db(
@@ -142,6 +143,7 @@ def connect(flush_cache=False, set_cache=False, oauth={}):
             authenticator=authenticator,
             ocsp_response_cache_filename='/tmp/.cache/snowflake/ocsp_response_cache',
             network_timeout=TIMEOUT,
+            region=region,
         )
 
     try:


### PR DESCRIPTION
Construct the snowflake hostname i.e. `{account}.snowflakecomputing.com` or `{account}.{region}.snowflakecomputing.com` following the [snowflake documentation](https://docs.snowflake.com/en/user-guide/oauth-custom.html#authorization-endpoint) for multiple regions. Inspired by https://github.com/snowflakedb/snowflake-connector-python/blob/e2d835d6e574e7e1856e60e703d9b5f8826e369a/src/snowflake/connector/connection.py#L686-L688 

Supplying the region to connect_db allows one to connect to the region specific endpoint for snowflake. Tested this change by building and running the web-ui docker image, I was able to login using oauth to the SnowAlert web ui to my snowflake account located in us-east-1.

Before these changes, I was not able to login using oauth as the web ui was hitting the default region endpoint (mydemo.snowflakecomputing.com) rather than (mydemo.us-east-1.snowflakecomputing.com). 
