### PR TITLE
Fix format button to activate if code is not empty

### DIFF
--- a/src/webui/frontend/src/components/RuleEditors/RawEditor.tsx
+++ b/src/webui/frontend/src/components/RuleEditors/RawEditor.tsx
@@ -70,7 +70,7 @@ class RawEditor extends React.PureComponent<RawEditorProps> {
         </Button>
         <Button
           type="default"
-          disabled={!rule}
+          disabled={!rule || rule.isSaving}
           onClick={() => rule && updateRuleBody(rule.viewName, sqlFormatter.format(rule.raw.body))}
         >
           <CheckCircleOutlined /> Format

--- a/src/webui/frontend/src/components/RuleEditors/RawEditor.tsx
+++ b/src/webui/frontend/src/components/RuleEditors/RawEditor.tsx
@@ -70,7 +70,7 @@ class RawEditor extends React.PureComponent<RawEditorProps> {
         </Button>
         <Button
           type="default"
-          disabled={!rule || !rule.isEdited}
+          disabled={!rule}
           onClick={() => rule && updateRuleBody(rule.viewName, sqlFormatter.format(rule.raw.body))}
         >
           <CheckCircleOutlined /> Format


### PR DESCRIPTION
**Changes**:
Fixed logic for `disabled=` property of format button as long as code is non-empty

**Tests**:
Ran the WebUI in dev

![image](https://user-images.githubusercontent.com/72515998/99019331-f2e91c80-2510-11eb-84c9-7363e5ca316a.png)
