### PR TITLE
Slack Group Message

### DIFF
--- a/src/runners/handlers/slack.py
+++ b/src/runners/handlers/slack.py
@@ -71,11 +71,11 @@ def handle(
     # Slack user id will be assigned as a channel
 
     title = alert['TITLE']
-    
+
     if recipient_email is not None:
         if isinstance(recipient_email, str):
             recipient_email = [recipient_email]
-                        
+
         users = []
         for email in recipient_email:
             response = sc.api_call("users.lookupByEmail", email=email)
@@ -83,13 +83,13 @@ def handle(
                 log.error(f'Cannot identify Slack user for email {email}')
                 continue
             users.append(response['user']['id'])
-        user_ids = ",".join(users)                  
+        user_ids = ",".join(users)
         result = sc.api_call("conversations.open", users=user_ids)
         if result['ok']:
             channel_id = result['channel']['id']
         else:
             raise RuntimeError(f"Error ocurred while opening conversation channel")
-            
+
     # check if channel exists, if yes notification will be delivered to the channel
     if channel is not None:
         log.info(f'Creating new SLACK message for {title} in channel', channel)
@@ -101,7 +101,7 @@ def handle(
             )
         else:
             raise RuntimeError("missing both 'channel' and 'recipient_email' param")
-    
+
     text = title
 
     if template is not None:


### PR DESCRIPTION
Slack Group Messages

case 1: When single recipient_email is passed i.e direct message:
<img width="1437" alt="Screenshot 2021-06-25 at 1 02 41 PM" src="https://user-images.githubusercontent.com/79505526/123388017-fddf5180-d5b5-11eb-9e7f-93f2b7be5e9c.png">
Output:
<img width="998" alt="Screenshot 2021-06-25 at 1 11 59 PM" src="https://user-images.githubusercontent.com/79505526/123388915-f7050e80-d5b6-11eb-87dd-ddd62098ba24.png">

Explaination:
Here, for Single Email, string will be be passed as recipient so, convert it into list.

if isinstance(recipient_email, str):
   recipient_email = [recipient_email]

case 2: When more than one recipient_email is passed i.e group slack creation:
<img width="1434" alt="Screenshot 2021-06-25 at 1 08 42 PM" src="https://user-images.githubusercontent.com/79505526/123388580-92e24a80-d5b6-11eb-9759-7a37b75165c2.png">
Output:
<img width="967" alt="Screenshot 2021-06-25 at 1 09 09 PM" src="https://user-images.githubusercontent.com/79505526/123388615-9d9cdf80-d5b6-11eb-9f2a-c7c3ad9ddebc.png">

Explaination:
If we get a list of emails, we need to iterate and get userId for each email and store it in as a list and then send all the ids as string by calling an API.

      for email in recipient_email:
          response = sc.api_call("users.lookupByEmail", email=email)
          if not response['ok']:
              log.error(f'Cannot identify Slack user for email {email}')
              continue
          users.append(response['user']['id'])
      user_ids = ",".join(users)                  
      result = sc.api_call("conversations.open", users=user_ids)