### PR TITLE
[awsic] fix oids param, options

### DIFF
--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1837,6 +1837,8 @@ async def aioingest(table_name, options, dryrun=False):
         if type(oids) is str
         else [str(oids)]
         if type(oids) is int
+        else map(str, oids)
+        if type(oids) is list
         else oids
     )
     num_entries = 0

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1796,9 +1796,12 @@ async def aioingest(table_name, options, dryrun=False):
     global AUDIT_ASSUMER_ARN
     global AUDIT_READER_ROLE
     global READER_EID
-    AUDIT_ASSUMER_ARN = options.get('audit_assumer_arn', '')
-    AUDIT_READER_ROLE = options.get('audit_reader_role', '')
-    READER_EID = options.get('reader_eid', '')
+    global AWS_ZONE
+
+    AUDIT_ASSUMER_ARN = options.get('audit_assumer_arn', AUDIT_ASSUMER_ARN)
+    AUDIT_READER_ROLE = options.get('audit_reader_role', AUDIT_READER_ROLE)
+    READER_EID = options.get('reader_eid', READER_EID)
+    AWS_ZONE = options.get('aws_zone', AWS_ZONE)
 
     collect_apis = (
         [


### PR DESCRIPTION
when passed in the command line, parameters were automatically parsed into a list of integers. instead, we want to treat it as a list of strings.