### PR TITLE
Add retry to db.fetch in alert_processor.py

### DIFF
--- a/src/runners/alert_processor.py
+++ b/src/runners/alert_processor.py
@@ -61,7 +61,13 @@ WHEN MATCHED THEN UPDATE SET
 
 def correlate():
   log.debug('correlating')
-  result = next(db.fetch(CORRELATE))
+  result = db.retry(
+        lambda: next(db.fetch(CORRELATE, fix_errors=False)),
+        E=StopIteration,
+        n=60,
+        log_errors=True,
+        sleep_seconds_btw_retry=60,
+    )
   log.debug(f'result: {result}')
   return result.get('number of rows updated')
 


### PR DESCRIPTION
Updated alert_processor to retry db.fetch, if it produces the `StopIteration` exception. 

Automated tests pass https://app.circleci.com/pipelines/github/snowflakedb/SnowAlert?branch=fix_db_fetch_exception&filter=all