### PR TITLE
GSE-3598

### DIFF
--- a/src/connectors/jamf_inventory.py
+++ b/src/connectors/jamf_inventory.py
@@ -93,28 +93,13 @@ def getAccessToken(credentials: str) -> str:
     # credentials stored in format {"client_id":"some-id","client_secret":"some-secret"}
     client_cred = json.loads(credentials)
 
-    jamf_token_api_path = "https://snowflake.jamfcloud.com/api/oauth/token"
-
-    data = {
-        'client_id': client_cred[CLIENT_ID_KEY],
-        'grant_type': 'client_credentials',
-        'client_secret': client_cred[CLIENT_SECRET_KEY],
-    }
-
     response = requests.post(
-        jamf_token_api_path,
-        data=urlencode(data),
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        'https://snowflake.jamfcloud.com/api/oauth/token',
+        data=client_cred,
     )
 
-    json_response = response.json()
+    access_token = response.json().get('access_token')
 
-    if ACCESS_TOKEN_KEY in json_response:
-        return json_response[ACCESS_TOKEN_KEY]
+    assert access_token is not None, "no access token in jamf oauth response"
 
-    log.error(
-        f"{ACCESS_TOKEN_KEY} not found in response from api : {jamf_token_api_path}"
-    )
-
-    # returning blank string  if access_token not found in response
-    return ""
+    return access_token

--- a/src/connectors/jamf_inventory.py
+++ b/src/connectors/jamf_inventory.py
@@ -27,11 +27,6 @@ CONNECTION_OPTIONS = [
 HEADERS: dict = {}
 REQUEST_SPEED_PER_SECOND = 10
 
-CLIENT_ID_KEY = "client_id"
-CLIENT_SECRET_KEY = "client_secret"
-
-ACCESS_TOKEN_KEY = "access_token"
-
 
 async def fetch(session, url, wait=0) -> dict:
     if wait:
@@ -90,7 +85,7 @@ def ingest(table_name, options):
 # options is a dict containing cliendId and clientSecret
 def getAccessToken(credentials: str) -> str:
 
-    # credentials stored in format {"client_id":"some-id","client_secret":"some-secret"}
+    # credentials stored in format {"client_id":"some-id",'"grant_type": "client_credentials","client_secret":"some-secret"}
     client_cred = json.loads(credentials)
 
     response = requests.post(

--- a/src/connectors/jamf_inventory.py
+++ b/src/connectors/jamf_inventory.py
@@ -77,20 +77,24 @@ async def main(table_name):
 
 def ingest(table_name, options):
     global HEADERS
-    token = getAccessToken(options=options['credentials'])
+    token = getAccessToken(json.loads(options['credentials']))
     HEADERS = {'Authorization': f'Bearer {token}', 'Accept': 'application/json'}
     return asyncio.get_event_loop().run_until_complete(main(f'data.{table_name}'))
 
 
-# options is a dict containing cliendId and clientSecret
-def getAccessToken(credentials: str) -> str:
-
-    # credentials stored in format {"client_id":"some-id",'"grant_type": "client_credentials","client_secret":"some-secret"}
-    client_cred = json.loads(credentials)
-
+def getAccessToken(credentials: dict) -> str:
+    """
+    Args:
+      credentials (dict): for jamfcloud oauth API, e.g. the json type:
+        {
+          "grant_type": "client_credentials",
+          "client_id": str,
+          "client_secret": str
+        }
+    """
     response = requests.post(
         'https://snowflake.jamfcloud.com/api/oauth/token',
-        data=client_cred,
+        data=credentials,
     )
 
     access_token = response.json().get('access_token')


### PR DESCRIPTION
Changing auth method with JAMF.
Moving to client credentials as JAMF is phasing out, basic auth.

this was tested by running the connector locally and verifying that the data is filled in `jamf_inventory_connection` table