### PR TITLE
GSE-3635: Fix AWSIC logging and status=408 errors

### DIFF
--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1706,7 +1706,6 @@ async def load_task_response(client, task):
                 yield x
 
     except (ClientError, DataNotFoundError, ServerTimeoutError) as e:
-        log.info(format_exception_only(e))
         for x in process_aws_response(task, e):
             yield x
 
@@ -1756,7 +1755,6 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
 
     except ClientError as e:
         # record missing auditor role as empty account summary
-        log.info(format_exception_only(e))
         yield (
             task.method,
             updated(

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,8 +6,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'aiohttp[speedups]==3.8.1',
-        'aioboto3==8.3.0',
+        'aiohttp[speedups]==3.9.5',
+        'aioboto3==12.4.0',
+        'aiobotocore==2.12.3',
         'demjson3==3.0.5',
         'fire==0.4.0',
         'jira==2.0.0',


### PR DESCRIPTION
Cleans up vestigial logging (known recoverable errors are written to `error` column in the ingestion tables) and fixes the crash that originates from a 408 response and logs —

```
botocore.parsers.ResponseParserError: Unable to parse response (no element found: line 1, column 0), invalid XML received. Further retries may succeed:
b''
```

This was reproduced locally and the retry logic appears to have fixed it, verified via local run.