### PR TITLE
Update base image to Python 3.8 on Debian bookworm

### DIFF
--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-bookworm
 
 WORKDIR /var/task
 

--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-bookworm
+FROM python:3.8-slim-bookworm
 
 WORKDIR /var/task
 


### PR DESCRIPTION
did not run test suite, but changes are minor per [python 3.8](https://www.python.org/downloads/release/python-380/) release notes