### PR TITLE
Update Dockerfile.snowalert to use iptables-legacy

### DIFF
--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -6,6 +6,10 @@ RUN apt-get update
 RUN apt-get install -y r-base
 RUN R -e "install.packages(c('dplyr', 'purrr', 'tidyr','MASS', 'tidyverse', 'broom','testthat'), repos = 'https://cloud.r-project.org')"
 
+# https://repost.aws/questions/QUCFqv7OfoQlygJrmwfkJ24Q/various-aws-apis-fail-due-to-timeout
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
 RUN pip install --upgrade pip virtualenv pyflakes
 
 RUN mkdir -p ./snowalert


### PR DESCRIPTION
fixing error
> botocore.exceptions.CredentialRetrievalError: Error when retrieving credentials from container-role: Error retrieving metadata: Received error when attempting to retrieve container metadata: Connect timeout on endpoint URL: "http://[ip]/v2/credentials/[uuid]"

per https://repost.aws/questions/QUCFqv7OfoQlygJrmwfkJ24Q/various-aws-apis-fail-due-to-timeout