### PR TITLE
Patch SnowAlert container image vulnerabilities.

### DIFF
--- a/Dockerfile.snowalert
+++ b/Dockerfile.snowalert
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm
+FROM python:3.9-slim-trixie
 
 WORKDIR /var/task
 
@@ -14,6 +14,7 @@ RUN virtualenv ./snowalert/venv
 ENV PATH="/var/task/snowalert/venv/bin:${PATH}"
 
 COPY ./src ./snowalert/src
+RUN rm -rf ./snowalert/src/webui
 COPY ./run ./run
 COPY ./install ./install
 RUN PYTHONPATH='' pip install ./snowalert/src/

--- a/src/runners/helpers/auth.py
+++ b/src/runners/helpers/auth.py
@@ -1,11 +1,11 @@
-"""Helpers specific for SnowAlert, dealing with authentication, e.g. to Snowflake DB.
-"""
+"""Helpers specific for SnowAlert, dealing with authentication, e.g. to Snowflake DB."""
+
 from typing import Optional, Union, Any
 from os import environ
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends.openssl.rsa import _RSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from requests import post
 from requests.auth import HTTPBasicAuth
 
@@ -19,7 +19,9 @@ URL_PREFIX = f'{PROTOCOL}://{{account}}.snowflakecomputing.com' + (
 )
 
 
-def load_pkb_rsa(p8_private_key: bytes, passphrase: Optional[bytes]) -> Union[_RSAPrivateKey, Any]:
+def load_pkb_rsa(
+    p8_private_key: bytes, passphrase: Optional[bytes]
+) -> Union[RSAPrivateKey, Any]:
     """Loads the rsa private key instead of just the bytes, using password
     decrypted with KMS. Required for the snowpipe SimpleIngestManager
     authentication flow.

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'aiohttp[speedups]==3.9.5',
+        'aiohttp[speedups]==3.12.14',
         'aioboto3==13.0.1',
         'demjson3==3.0.5',
         'fire==0.4.0',
@@ -35,7 +35,7 @@ setup(
         'sentry-sdk==1.5.4',
         'pdpyras==4.4.0',
         'duo_client==4.2.3',
-        'cryptography==36.0.1',
+        'cryptography==43.0.1',
         'requests==2.27.1',
         'pymsteams==0.1.14',
     ],


### PR DESCRIPTION
Changes:
* Upgrade base image from `3.9-slim-bookworm` to `python:3.9-slim-trixie`
* Upgrade `aiohttp` python package from version 3.9.5 to version 3.12.14
* Upgrade `cryptography` python package from version 36.0.1 to 43.0.1, including changing the depreciated references
* Remove `./snowalert/src/webui` directory due to many nodejs packages vulnerabilities and we already have a separate Docker file specifically for SnowAlert webui.