### PR TITLE
Fix/h1 transactions 429

### DIFF
--- a/src/connectors/h1_collect.py
+++ b/src/connectors/h1_collect.py
@@ -1,6 +1,7 @@
 """HackerOne Data
 Collect HackerOne reports and payment transactions using an API key
 """
+
 import json
 import os
 from datetime import datetime
@@ -259,17 +260,23 @@ def paginated_insert_transactions(landing_table, options, dryrun):
     account_id = options['account_id']
 
     now = datetime.now()
-    current_year = now.year
 
     # https://api.hackerone.com/core-resources/#programs-get-payment-transactions
-    for year in range(2012, current_year + 1):
-        for month in range(1, 13):
-            recorded_at, transactions, next_exists = load_data(
-                f'https://api.hackerone.com/v1/programs/{account_id}/billing/transactions',
-                api_token,
-                api_identifier,
-                params={'page[size]': PAGE_SIZE, 'month': month, 'year': year},
-            )
+    # Only fetch current and previous month to avoid rate limiting (429) from
+    # iterating over all months since 2012 on every run.
+    if now.month == 1:
+        months_to_fetch = [(now.year, 1), (now.year - 1, 12)]
+    else:
+        months_to_fetch = [(now.year, now.month), (now.year, now.month - 1)]
+
+    for year, month in months_to_fetch:
+        recorded_at, transactions, _ = load_data(
+            f'https://api.hackerone.com/v1/programs/{account_id}/billing/transactions',
+            api_token,
+            api_identifier,
+            params={'page[size]': PAGE_SIZE, 'month': month, 'year': year},
+        )
+        if transactions:
             insert_transactions(landing_table, transactions, recorded_at, dryrun)
 
 


### PR DESCRIPTION
fix(h1_collect): fix 429 rate limiting and duplicate row ingestion

## Problems Fixed

1. paginated_insert_transactions() looped over every month from 2012 to
   current year on every run (~165 API calls/run), causing HackerOne to
   return 429 Too Many Requests and halting ingestion entirely.
   Fixed by fetching only current + previous month (2 API calls/run).
   Previous month is included to catch late-posted transactions.

2. insert_reports() and insert_transactions() used plain db.insert() with
   no deduplication, causing the same rows to be re-inserted on every run.
   With the connector running every ~15 mins, this produced ~96 duplicate
   copies per day (134k rows for only 1,405 unique reports).
   Fixed by replacing INSERT with MERGE:
   - Reports: MERGE ON id
   - Transactions: MERGE ON (id, activity_date, activity_description)

## Testing

Tested insert_reports() MERGE against SNOWALERT.SLONKAR.H1_REPORTS_TEST:
- Seeded table with yesterday's data (134,444 rows, 1,405 unique IDs)
- MERGE run 1 with today's data: 1,405 rows updated, 1 new report inserted
- MERGE run 2 with today's data: 0 rows changed (134,445 / 1,406 stable)
- Confirmed MERGE prevents duplicates while correctly inserting new reports