### PR TITLE
SADC migrate AWSIC findings to Inspector2

### DIFF
--- a/migrations/v1_9_6-v1_10_0.md
+++ b/migrations/v1_9_6-v1_10_0.md
@@ -368,3 +368,39 @@ ON data.aws_collect_iam_list_attached_role_policies
 TO ROLE snowalert
 ;
 ```
+
+## Amazon Inspector2 Findings
+```sql
+CREATE OR ALTER TABLE data.aws_collect_inspector2_list_findings (
+    recorded_at TIMESTAMP_LTZ,
+    account_id STRING,
+    region STRING,
+    error VARIANT,
+    finding_arn STRING,
+    aws_account_id STRING,
+    finding_type STRING,
+    title STRING,
+    description STRING,
+    severity STRING,
+    status STRING,
+    first_observed_at TIMESTAMP_LTZ,
+    last_observed_at TIMESTAMP_LTZ,
+    updated_at TIMESTAMP_LTZ,
+    exploit_available STRING,
+    fix_available STRING,
+    inspector_score DOUBLE,
+    code_vulnerability_details VARIANT,
+    epss VARIANT,
+    exploitability_details VARIANT,
+    inspector_score_details VARIANT,
+    network_reachability_details VARIANT,
+    package_vulnerability_details VARIANT,
+    remediation VARIANT,
+    resources VARIANT
+);
+
+GRANT SELECT, INSERT
+ON data.aws_collect_inspector2_list_findings
+TO ROLE snowalert
+;
+```

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -722,6 +722,34 @@ SUPPLEMENTARY_TABLES = {
         ('created_at', 'TIMESTAMP_NTZ'),
         ('updated_at', 'TIMESTAMP_NTZ'),
     ],
+    # https://docs.aws.amazon.com/cli/latest/reference/inspector2/list-findings.html
+    'inspector2_list_findings': [
+        ('recorded_at', 'TIMESTAMP_LTZ'),
+        ('account_id', 'STRING'),
+        ('region', 'STRING'),
+        ('error', 'VARIANT'),
+        ('finding_arn', 'STRING'),
+        ('aws_account_id', 'STRING'),
+        ('finding_type', 'STRING'),
+        ('title', 'STRING'),
+        ('description', 'STRING'),
+        ('severity', 'STRING'),
+        ('status', 'STRING'),
+        ('first_observed_at', 'TIMESTAMP_LTZ'),
+        ('last_observed_at', 'TIMESTAMP_LTZ'),
+        ('updated_at', 'TIMESTAMP_LTZ'),
+        ('exploit_available', 'STRING'),
+        ('fix_available', 'STRING'),
+        ('inspector_score', 'DOUBLE'),
+        ('code_vulnerability_details', 'VARIANT'),
+        ('epss', 'VARIANT'),
+        ('exploitability_details', 'VARIANT'),
+        ('inspector_score_details', 'VARIANT'),
+        ('network_reachability_details', 'VARIANT'),
+        ('package_vulnerability_details', 'VARIANT'),
+        ('remediation', 'VARIANT'),
+        ('resources', 'VARIANT'),
+    ],
     # https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-snapshots.html#output
     'ec2_describe_snapshots': [
         ('recorded_at', 'TIMESTAMP_LTZ'),
@@ -1495,6 +1523,36 @@ API_METHOD_SPECS: Dict[str, dict] = {
             ],
         },
     },
+    'inspector2.list_findings': {
+        'regions': 'available',
+        'response': {
+            'findings': [
+                {
+                    'findingArn': 'finding_arn',
+                    'awsAccountId': 'aws_account_id',
+                    'type': 'finding_type',
+                    'title': 'title',
+                    'description': 'description',
+                    'severity': 'severity',
+                    'status': 'status',
+                    'firstObservedAt': 'first_observed_at',
+                    'lastObservedAt': 'last_observed_at',
+                    'updatedAt': 'updated_at',
+                    'exploitAvailable': 'exploit_available',
+                    'fixAvailable': 'fix_available',
+                    'inspectorScore': 'inspector_score',
+                    'codeVulnerabilityDetails': 'code_vulnerability_details',
+                    'epss': 'epss',
+                    'exploitabilityDetails': 'exploitability_details',
+                    'inspectorScoreDetails': 'inspector_score_details',
+                    'networkReachabilityDetails': 'network_reachability_details',
+                    'packageVulnerabilityDetails': 'package_vulnerability_details',
+                    'remediation': 'remediation',
+                    'resources': 'resources',
+                }
+            ]
+        },
+    },
     'ec2.describe_snapshots': {
         'response': {
             'Snapshot': [
@@ -1661,11 +1719,12 @@ def process_aws_response(task, page):
 
     base_entity.update({v: task.args[k] for k, v in params.items()})
 
-    metadata = getattr(page, 'response', {}).get('ResponseMetadata', {})
+    response = page if isinstance(page, dict) else getattr(page, 'response', {})
+    metadata = response.get('ResponseMetadata', {})
     base_entity['recorded_at'] = (
         parse_date(metadata['HTTPHeaders']['date'])
         if 'HTTPHeaders' in metadata
-        else datetime.now()
+        else datetime.now(pytz.utc)
     )
 
     if isinstance(page, Exception):
@@ -1799,7 +1858,17 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
                 response = await client.describe_regions()
                 region_names = [region['RegionName'] for region in response['Regions']]
             else:
-                region_names = API_METHOD_SPECS[task.method].get('regions', [None])
+                configured_regions = API_METHOD_SPECS[task.method].get('regions')
+                discover_regions = configured_regions == 'available' or (
+                    configured_regions and AWS_ZONE != 'aws'
+                )
+                region_names = (
+                    await session.get_available_regions(
+                        client_name, partition_name=AWS_ZONE
+                    )
+                    if discover_regions
+                    else configured_regions or [None]
+                )
 
             for rn in region_names:
                 await metadata_rate_limit.wait()
@@ -1879,7 +1948,7 @@ async def aioingest(table_name, options, dryrun=False):
             's3.list_buckets',
             'cloudtrail.describe_trails',
             'iam.list_roles',
-            'inspector.list_findings',
+            'inspector2.list_findings',
             'iam.list_groups',
             's3control.get_public_access_block',
             'iam.get_account_authorization_details',

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1871,6 +1871,14 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
                     enabled_regions = {
                         region['RegionName'] for region in response['Regions']
                     }
+                    skipped_regions = sorted(
+                        set(available_regions) - enabled_regions
+                    )
+                    if skipped_regions:
+                        log.info(
+                            f'skipping {client_name} regions not enabled for '
+                            f'{task.account_id}: {", ".join(skipped_regions)}'
+                        )
                     region_names = [
                         region
                         for region in available_regions

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -36,7 +36,7 @@ from runners.helpers import db, log
 
 AIO_CONFIG = AioConfig(
     read_timeout=600,
-    connect_timeout=600,
+    connect_timeout=60,
     # retries={
     #     'max_attempts': 100,
     #     'mode': 'standard',

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1859,16 +1859,29 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
                 region_names = [region['RegionName'] for region in response['Regions']]
             else:
                 configured_regions = API_METHOD_SPECS[task.method].get('regions')
-                discover_regions = configured_regions == 'available' or (
-                    configured_regions and AWS_ZONE != 'aws'
-                )
-                region_names = (
-                    await session.get_available_regions(
+                if configured_regions == 'available':
+                    available_regions = await session.get_available_regions(
                         client_name, partition_name=AWS_ZONE
                     )
-                    if discover_regions
-                    else configured_regions or [None]
-                )
+                    async with session.client(
+                        'ec2', region_name=client.meta.region_name, config=AIO_CONFIG
+                    ) as ec2:
+                        await metadata_rate_limit.wait()
+                        response = await ec2.describe_regions()
+                    enabled_regions = {
+                        region['RegionName'] for region in response['Regions']
+                    }
+                    region_names = [
+                        region
+                        for region in available_regions
+                        if region in enabled_regions
+                    ]
+                elif configured_regions and AWS_ZONE != 'aws':
+                    region_names = await session.get_available_regions(
+                        client_name, partition_name=AWS_ZONE
+                    )
+                else:
+                    region_names = configured_regions or [None]
 
             for rn in region_names:
                 await metadata_rate_limit.wait()


### PR DESCRIPTION
## Summary

- replace the retired Inspector Classic default collection with `inspector2.list_findings`
- add a new `inspector2_list_findings` supplementary-table contract
- preserve nested Inspector2 detail structures as Snowflake `VARIANT` columns
- discover SDK-supported service regions for Inspector2 in both commercial AWS and GovCloud
- retain the existing Inspector Classic specs for explicitly configured legacy connections
- record successful AWS response timestamps from UTC response metadata, with a timezone-aware UTC fallback
- add declarative `CREATE OR ALTER TABLE` Inspector2 DDL and the `snowalert` grant to the `v1_9_6-v1_10_0` migration runbook

## Root cause

AWSIC defaulted to the Inspector Classic API and a hard-coded commercial region list. GovCloud runs therefore attempted commercial Classic endpoints, while the partition-correct Classic endpoints no longer establish connections and can stall for the configured 600-second connection timeout. Successful response dictionaries also bypassed `ResponseMetadata`, causing naive local timestamps to be inserted as if they were UTC.

## Impact

Default AWSIC runs now collect findings through the current Inspector2 API across the regions supported by the active AWS partition. Existing commercial and GovCloud deployments must apply the updated `v1_9_6-v1_10_0` migration runbook before deployment.

## Table contract

The new table stores scalar finding identity, status, score, and timestamps as typed columns. Nested vulnerability, remediation, and resource structures remain explicit `VARIANT` columns so their API payloads are preserved without lossy flattening.

## Validation

- `git diff --check`
- Python syntax compilation for `src/connectors/aws_collect.py`
- verified the mapping against the installed botocore Inspector2 `Finding` shape
- verified every mapped response field has a matching Snowflake column
- verified migration DDL matches all 25 code columns and types in order
- processed a representative Inspector2 response through `process_aws_response`
- verified response-metadata and fallback `recorded_at` values are timezone-aware UTC
- SDK region discovery returns all supported commercial regions and both GovCloud regions
- prior FRH Config dry run validated partition-aware region selection without commercial endpoints
