### PR TITLE
filter AWS regions by opt-in status

### DIFF
--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1849,6 +1849,19 @@ async def get_session(account_arn):
     return (None, value) if expiration is NEVER else (value, None)
 
 
+def split_regions_by_opt_in_status(response):
+    enabled_regions = []
+    disabled_regions = []
+    for region in response['Regions']:
+        destination = (
+            disabled_regions
+            if region.get('OptInStatus') == 'not-opted-in'
+            else enabled_regions
+        )
+        destination.append(region['RegionName'])
+    return enabled_regions, disabled_regions
+
+
 async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]:
     account_arn = f'arn:{AWS_ZONE}:iam::{task.account_id}:role/{AUDIT_READER_ROLE}'
     account_info = {'account_id': task.account_id}
@@ -1862,8 +1875,15 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
         async with session.client(client_name, config=AIO_CONFIG) as client:
             if hasattr(client, 'describe_regions'):
                 await metadata_rate_limit.wait()
-                response = await client.describe_regions()
-                region_names = [region['RegionName'] for region in response['Regions']]
+                response = await client.describe_regions(AllRegions=True)
+                region_names, skipped_regions = split_regions_by_opt_in_status(
+                    response
+                )
+                if skipped_regions:
+                    log.info(
+                        f'skipping {client_name} regions not enabled for '
+                        f'{task.account_id}: {", ".join(sorted(skipped_regions))}'
+                    )
             else:
                 configured_regions = API_METHOD_SPECS[task.method].get('regions')
                 if configured_regions == 'available':
@@ -1874,10 +1894,11 @@ async def process_task(task, add_task) -> AsyncGenerator[Tuple[str, dict], None]
                         'ec2', region_name=client.meta.region_name, config=AIO_CONFIG
                     ) as ec2:
                         await metadata_rate_limit.wait()
-                        response = await ec2.describe_regions()
-                    enabled_regions = {
-                        region['RegionName'] for region in response['Regions']
-                    }
+                        response = await ec2.describe_regions(AllRegions=True)
+                    enabled_region_names, _ = split_regions_by_opt_in_status(
+                        response
+                    )
+                    enabled_regions = set(enabled_region_names)
                     skipped_regions = sorted(
                         set(available_regions) - enabled_regions
                     )

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1799,22 +1799,13 @@ async def load_task_response(client, task):
             ):
                 yield x
 
-    # todo: double check whether these should be retried instead of recording errors
-    except (
-        ClientError,
-        ConnectTimeoutError,
-        DataNotFoundError,
-        EndpointConnectionError,
-        ServerTimeoutError,
-    ) as e:
-        if isinstance(
-            e, (ConnectTimeoutError, EndpointConnectionError, ServerTimeoutError)
-        ):
-            log.error(
-                f'{task.method} failed for {task.account_id} in '
-                f'{client.meta.region_name}: ',
-                e,
-            )
+    except (ConnectTimeoutError, EndpointConnectionError, ServerTimeoutError) as e:
+        log.error(
+            f'{task.method} failed for {task.account_id} in '
+            f'{client.meta.region_name}: ',
+            e,
+        )
+    except (ClientError, DataNotFoundError) as e:
         for x in process_aws_response(task, e):
             yield x
 

--- a/src/connectors/aws_collect.py
+++ b/src/connectors/aws_collect.py
@@ -1807,6 +1807,14 @@ async def load_task_response(client, task):
         EndpointConnectionError,
         ServerTimeoutError,
     ) as e:
+        if isinstance(
+            e, (ConnectTimeoutError, EndpointConnectionError, ServerTimeoutError)
+        ):
+            log.error(
+                f'{task.method} failed for {task.account_id} in '
+                f'{client.meta.region_name}: ',
+                e,
+            )
         for x in process_aws_response(task, e):
             yield x
 

--- a/src/connectors/tests/test_aws_collect.py
+++ b/src/connectors/tests/test_aws_collect.py
@@ -1,9 +1,22 @@
+import asyncio
 from collections import namedtuple
 from datetime import datetime
+from types import SimpleNamespace
 
-from botocore.exceptions import BotoCoreError
+from aiohttp.client_exceptions import ServerTimeoutError
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+)
 
-from connectors.aws_collect import process_aws_response, DBEntry, CollectTask
+from connectors.aws_collect import (
+    CollectTask,
+    DBEntry,
+    load_task_response,
+    process_aws_response,
+)
 
 
 Sample = namedtuple('Sample', ['task', 'response', 'entities', 'subrequests'])
@@ -12,6 +25,25 @@ Sample = namedtuple('Sample', ['task', 'response', 'entities', 'subrequests'])
 class AnyDate(object):
     def __eq__(self, other):
         return isinstance(other, datetime)
+
+
+class ErroringClient:
+    meta = SimpleNamespace(region_name='us-east-1')
+
+    def __init__(self, error):
+        self.error = error
+
+    def can_paginate(self, method_name):
+        return False
+
+    async def list_account_aliases(self, **kwargs):
+        raise self.error
+
+
+async def collect_task_responses(error):
+    client = ErroringClient(error)
+    task = CollectTask('1', 'iam.list_account_aliases', {})
+    return [response async for response in load_task_response(client, task)]
 
 
 TEST_DATA_REQUEST_RESPONSE = [
@@ -230,3 +262,29 @@ def test_process_aws_response():
                 child_requests.append(r)
         assert sample.entities == db_entries
         assert sample.subrequests == child_requests
+
+
+def test_load_task_response_does_not_record_network_errors():
+    network_errors = (
+        ConnectTimeoutError(endpoint_url='https://iam.amazonaws.com'),
+        EndpointConnectionError(endpoint_url='https://iam.amazonaws.com'),
+        ServerTimeoutError(),
+    )
+
+    for error in network_errors:
+        assert asyncio.run(collect_task_responses(error)) == []
+
+
+def test_load_task_response_records_aws_api_errors():
+    error = ClientError(
+        {
+            'Error': {'Code': 'AccessDenied', 'Message': 'denied'},
+            'ResponseMetadata': {'HTTPStatusCode': 403},
+        },
+        'ListAccountAliases',
+    )
+
+    responses = asyncio.run(collect_task_responses(error))
+
+    assert len(responses) == 1
+    assert responses[0].entity['error']['exceptionName'] == 'ClientError'


### PR DESCRIPTION
This is hardening, not new functionality. AWSIC now fetches all regions, skips those the account has explicitly not opted into, and logs the skipped regions to avoid calls to disabled endpoints.

Transport failures such as connect, endpoint, and server timeouts are logged as operational failures and are not persisted as AWS API error responses. AWS API errors such as `AccessDenied` continue to be recorded.

Tests: `cd src && ../.venv/bin/pytest -q connectors/tests/test_aws_collect.py`
